### PR TITLE
docs: 全 Java ソースに日本語 Javadoc を追加

### DIFF
--- a/mapoker-backend/src/main/java/com/mapoker/MapokerApplication.java
+++ b/mapoker-backend/src/main/java/com/mapoker/MapokerApplication.java
@@ -4,10 +4,25 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
+/**
+ * Spring Boot アプリケーションのエントリポイント。
+ *
+ * <p>{@code @ConfigurationPropertiesScan} により、{@code CorsProperties} や {@code GameProperties}
+ * をはじめとする {@code @ConfigurationProperties} クラスが自動検出される。
+ * 新しい設定カテゴリを追加した場合もこのクラスへの追記は不要。
+ *
+ * <p>認証を無効化したローカル開発モードで起動するには {@code SPRING_PROFILES_ACTIVE=local} を設定する。
+ * PostgreSQL を使用する場合は {@code postgresql} プロファイルを追加する。
+ */
 @SpringBootApplication
 @ConfigurationPropertiesScan
 public class MapokerApplication {
 
+	/**
+	 * アプリケーションを起動する。
+	 *
+	 * @param args コマンドライン引数（Spring Boot の標準引数形式をサポート）
+	 */
 	public static void main(String[] args) {
 		SpringApplication.run(MapokerApplication.class, args);
 	}

--- a/mapoker-backend/src/main/java/com/mapoker/application/ActionRecord.java
+++ b/mapoker-backend/src/main/java/com/mapoker/application/ActionRecord.java
@@ -2,4 +2,16 @@ package com.mapoker.application;
 
 import com.mapoker.domain.rules.ActionType;
 
+/**
+ * 1回のプレイヤーアクションを表す不変レコード。
+ *
+ * <p>{@link GameRepository} への永続化および履歴取得に使用される。
+ * {@code amount} の意味は {@link ActionType} によって異なる。
+ * {@code bet}/{@code raise} の場合は raise-to トータル額、{@code call} の場合は 0 で自動コール。
+ *
+ * @param seq         ゲーム内でのアクション通し番号（1始まり）
+ * @param playerIndex アクションを実行したプレイヤーのシートインデックス
+ * @param actionType  アクションの種別（{@link ActionType}）
+ * @param amount      アクションに伴う金額（chips）。fold / check は 0
+ */
 public record ActionRecord(int seq, int playerIndex, ActionType actionType, int amount) {}

--- a/mapoker-backend/src/main/java/com/mapoker/application/GameRepository.java
+++ b/mapoker-backend/src/main/java/com/mapoker/application/GameRepository.java
@@ -4,11 +4,68 @@ import com.mapoker.domain.game.GameState;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * ゲーム状態の永続化を担うリポジトリポート。
+ *
+ * <p>実装は Spring プロファイルにより切り替わる。
+ * {@code local} プロファイルではインメモリ実装、{@code postgresql} プロファイルでは
+ * PostgreSQL 実装が使用される。
+ *
+ * <p>{@link #update(String, GameState, ActionRecord)} は ゲーム状態の更新とアクションの
+ * 挿入を単一トランザクションで行う必要がある。
+ */
 public interface GameRepository {
+
+    /**
+     * 新規ゲームを永続化する。
+     *
+     * @param id    ゲームを一意に識別する UUID 文字列
+     * @param state 初期化済みの {@link GameState}
+     */
     void create(String id, GameState state);
+
+    /**
+     * ゲーム状態を更新し、同時にアクションを記録する。
+     *
+     * <p>状態更新とアクション挿入は同一トランザクション内で完結させること。
+     *
+     * @param id     ゲーム ID
+     * @param state  更新後の {@link GameState}
+     * @param action 今回適用されたアクション
+     */
     void update(String id, GameState state, ActionRecord action);
+
+    /**
+     * アクションを伴わずにゲーム状態のみを更新する。
+     *
+     * <p>ハンド開始・ショーダウン適用など、アクション記録が不要な更新に使用する。
+     *
+     * @param id    ゲーム ID
+     * @param state 更新後の {@link GameState}
+     */
     void update(String id, GameState state);
+
+    /**
+     * 指定 ID のゲームを取得する。
+     *
+     * @param id ゲーム ID
+     * @return ゲームが存在する場合は {@link Optional} でラップされた {@link GameState}、
+     *         存在しない場合は {@link Optional#empty()}
+     */
     Optional<GameState> findById(String id);
+
+    /**
+     * 全ゲームを取得する。
+     *
+     * @return 全 {@link GameState} のリスト
+     */
     List<GameState> findAll();
+
+    /**
+     * 指定ゲームに記録された全アクション履歴を取得する。
+     *
+     * @param gameId ゲーム ID
+     * @return アクション履歴のリスト（{@code seq} 昇順）
+     */
     List<ActionRecord> findActionsByGameId(String gameId);
 }

--- a/mapoker-backend/src/main/java/com/mapoker/application/GameService.java
+++ b/mapoker-backend/src/main/java/com/mapoker/application/GameService.java
@@ -18,6 +18,19 @@ import java.util.NoSuchElementException;
 import java.util.Random;
 import java.util.UUID;
 
+/**
+ * ゲームのライフサイクル管理を担うアプリケーションサービス。
+ *
+ * <p>ゲームの作成・アクション適用・ショーダウン解決を責務とする。
+ * ドメイン層（{@link com.mapoker.domain.game.GameState}）への操作は
+ * すべてこのクラスを経由する。
+ *
+ * <p>ハンド終了時には自動的に {@link HandHistoryService#record} を呼び出す。
+ * また fold-win / showdown 解決後は {@link TableService#processPendingLeaves} を
+ * トリガーして離席待ちプレイヤーを処理する。
+ *
+ * <p>循環依存を避けるため {@link TableService} は {@link ObjectProvider} 経由で取得する。
+ */
 @Service
 public class GameService {
 
@@ -35,6 +48,16 @@ public class GameService {
         this.tableServiceProvider = tableServiceProvider;
     }
 
+    /**
+     * 新規ゲームを作成して永続化する。
+     *
+     * @param playerInputs  プレイヤーリスト（ID とスタック）
+     * @param buttonIndex   ボタンポジションの初期インデックス
+     * @param bigBlind      ビッグブラインドのチップ額
+     * @param seed          乱数シード（{@code null} の場合はランダム）
+     * @param oddChipRule   端数チップの配分ルール
+     * @return 作成された {@link GameState}
+     */
     public GameState createGame(List<PlayerInput> playerInputs, int buttonIndex, int bigBlind,
                                 Long seed, OddChipRule oddChipRule) {
         List<Player> players = playerInputs.stream()
@@ -48,15 +71,37 @@ public class GameService {
         return state;
     }
 
+    /**
+     * 指定 ID のゲームを取得する。
+     *
+     * @param id ゲーム ID
+     * @return 対応する {@link GameState}
+     * @throws NoSuchElementException ゲームが存在しない場合
+     */
     public GameState getGame(String id) {
         return gameRepository.findById(id)
                 .orElseThrow(() -> new NoSuchElementException("game not found: " + id));
     }
 
+    /**
+     * 全ゲームを取得する。
+     *
+     * @return 全 {@link GameState} のリスト
+     */
     public List<GameState> listGames() {
         return gameRepository.findAll();
     }
 
+    /**
+     * 指定テーブルで新しいハンドを開始する。
+     *
+     * <p>ゲームの状態が {@code finished} であることを前提とする。
+     * ブラインドポスト・デッキのシャッフル・ホールカードの配布を行う。
+     *
+     * @param id       ゲーム ID
+     * @param bigBlind このハンドのビッグブラインド額
+     * @return 更新後の {@link GameState}
+     */
     public GameState startHand(String id, int bigBlind) {
         GameState state = getGame(id);
         state.startHand(bigBlind);
@@ -64,6 +109,18 @@ public class GameService {
         return state;
     }
 
+    /**
+     * リングゲーム用のゲームを作成する。
+     *
+     * <p>通常の {@link #createGame} と異なり、初期ステータスを {@code FINISHED} に設定して
+     * テーブルが「待機中」として表示されるようにする。
+     * プレイヤーのスタックは 0 で初期化され、join 時に buy-in 額が設定される。
+     *
+     * @param playerInputs プレイヤーリスト（ID とスタック）
+     * @param bigBlind     ビッグブラインドのチップ額
+     * @param oddChipRule  端数チップの配分ルール
+     * @return 作成された {@link GameState}
+     */
     public GameState createRingGame(List<PlayerInput> playerInputs, int bigBlind, OddChipRule oddChipRule) {
         List<Player> players = playerInputs.stream()
                 .map(pi -> new Player(pi.id(), pi.stack()))
@@ -76,12 +133,29 @@ public class GameService {
         return state;
     }
 
+    /**
+     * ボタン位置を更新する。
+     *
+     * <p>SB/BB ローテーションを手動で制御する際に使用する。
+     *
+     * @param tableId     ゲーム ID
+     * @param buttonIndex 新しいボタンポジションのシートインデックス
+     */
     public void setButtonIndex(String tableId, int buttonIndex) {
         GameState state = getGame(tableId);
         state.setButtonIndex(buttonIndex);
         gameRepository.update(tableId, state);
     }
 
+    /**
+     * 指定シートのスタック額を設定する。
+     *
+     * <p>buy-in・cash-out・スタックリセット時に使用する。
+     *
+     * @param tableId   ゲーム ID
+     * @param seatIndex 対象シートのインデックス
+     * @param amount    新しいスタック額（chips）
+     */
     public void setSeatStack(String tableId, int seatIndex, int amount) {
         GameState state = getGame(tableId);
         Player player = state.getPlayers().get(seatIndex);
@@ -89,17 +163,45 @@ public class GameService {
         gameRepository.update(tableId, state);
     }
 
+    /**
+     * 指定シートの着席状態（sitting out）を設定する。
+     *
+     * <p>ハンド進行中に join したプレイヤーを次のハンドまで待機させる際に使用する。
+     *
+     * @param tableId   ゲーム ID
+     * @param seatIndex 対象シートのインデックス
+     * @param value     {@code true} で sitting out、{@code false} で復帰
+     */
     public void setSittingOut(String tableId, int seatIndex, boolean value) {
         GameState state = getGame(tableId);
         state.getPlayers().get(seatIndex).setSittingOut(value);
         gameRepository.update(tableId, state);
     }
 
+    /**
+     * 指定シートの現在スタック額を取得する。
+     *
+     * @param tableId   ゲーム ID
+     * @param seatIndex 対象シートのインデックス
+     * @return 現在のスタック額（chips）
+     */
     public int getSeatStack(String tableId, int seatIndex) {
         GameState state = getGame(tableId);
         return state.getPlayers().get(seatIndex).getStack();
     }
 
+    /**
+     * プレイヤーアクションを適用し、ゲーム状態を更新する。
+     *
+     * <p>アクション適用後、ゲームが終了していれば {@link HandHistoryService#record} を呼び出す。
+     * fold-win の場合は {@link TableService#processPendingLeaves} もトリガーする。
+     *
+     * @param id          ゲーム ID
+     * @param playerIndex アクションを行うプレイヤーのシートインデックス
+     * @param type        アクション種別
+     * @param amount      金額（{@code bet}/{@code raise} は raise-to トータル額、{@code call} は 0）
+     * @return 更新後の {@link GameState}
+     */
     public GameState applyAction(String id, int playerIndex, ActionType type, int amount) {
         GameState state = getGame(id);
         Action action = Action.of(type, amount);
@@ -118,11 +220,29 @@ public class GameService {
         return state;
     }
 
+    /**
+     * 指定ゲームのアクション履歴を取得する。
+     *
+     * <p>ゲームが存在しない場合は例外をスローする（存在確認を兼ねる）。
+     *
+     * @param id ゲーム ID
+     * @return アクション履歴のリスト
+     * @throws NoSuchElementException ゲームが存在しない場合
+     */
     public List<ActionRecord> getActions(String id) {
         getGame(id);
         return gameRepository.findActionsByGameId(id);
     }
 
+    /**
+     * ショーダウンを解決してポットを配分する。
+     *
+     * <p>ハンド評価・サイドポット計算・ペイアウト適用を行い、ゲームを {@code finished} 状態に遷移させる。
+     * 処理後は {@link HandHistoryService#record} および {@link TableService#processPendingLeaves} を呼び出す。
+     *
+     * @param id ゲーム ID
+     * @return ショーダウン結果（勝者・ペイアウト等）
+     */
     public ShowdownResult resolveShowdown(String id) {
         GameState state = getGame(id);
         ShowdownResult result = state.resolveShowdown();
@@ -207,5 +327,11 @@ public class GameService {
         return List.copyOf(masked);
     }
 
+    /**
+     * ゲーム作成時のプレイヤー入力パラメータ。
+     *
+     * @param id    プレイヤー識別子（ユーザー名または座席識別子）
+     * @param stack 初期スタック額（chips）
+     */
     public record PlayerInput(String id, int stack) {}
 }

--- a/mapoker-backend/src/main/java/com/mapoker/application/HandHistoryEntry.java
+++ b/mapoker-backend/src/main/java/com/mapoker/application/HandHistoryEntry.java
@@ -3,6 +3,22 @@ package com.mapoker.application;
 import java.time.Instant;
 import java.util.List;
 
+/**
+ * 1ハンド分の履歴を保持する不変レコード。
+ *
+ * <p>ハンド終了時（fold-win またはショーダウン後）に {@link HandHistoryService#record} 経由で
+ * {@link HandHistoryRepository} に永続化される。
+ *
+ * <p>{@code players} および {@code winners} は {@code null} を渡しても空リストに正規化される。
+ *
+ * @param tableId    テーブル（ゲーム）ID
+ * @param handId     ハンド固有の UUID
+ * @param players    各プレイヤーのスナップショット（{@link PlayerSnapshot}）
+ * @param winners    勝者のシートインデックスリスト
+ * @param pot        このハンドのトータルポット額（chips）
+ * @param street     終了ストリートのラベル（例: {@code "preflop"}, {@code "river"}）
+ * @param finishedAt ハンド終了時刻
+ */
 public record HandHistoryEntry(
         String tableId,
         String handId,
@@ -17,6 +33,19 @@ public record HandHistoryEntry(
         winners = winners == null ? List.of() : List.copyOf(winners);
     }
 
+    /**
+     * ハンド終了時点でのプレイヤーの状態スナップショット。
+     *
+     * <p>{@code name} が空の場合は {@code "Seat N"} にフォールバックする。
+     * {@code holeCards} は履歴保存時点ではマスク済みの {@code "??"} で格納される。
+     *
+     * @param name        プレイヤー名（テーブルメンバー名、または座席 ID のフォールバック）
+     * @param seatIndex   シートインデックス
+     * @param stackBefore ハンド開始前のスタック額
+     * @param stackAfter  ハンド終了後のスタック額
+     * @param folded      フォールドしていた場合 {@code true}
+     * @param holeCards   ホールカードのリスト（マスク済み）
+     */
     public record PlayerSnapshot(
             String name,
             int seatIndex,

--- a/mapoker-backend/src/main/java/com/mapoker/application/HandHistoryRepository.java
+++ b/mapoker-backend/src/main/java/com/mapoker/application/HandHistoryRepository.java
@@ -2,9 +2,24 @@ package com.mapoker.application;
 
 import java.util.List;
 
+/**
+ * ハンド履歴の永続化と取得を担当するリポジトリです。
+ */
 public interface HandHistoryRepository {
 
+    /**
+     * ハンド履歴を保存します。
+     *
+     * @param entry 保存するハンド履歴
+     */
     void save(HandHistoryEntry entry);
 
+    /**
+     * 指定したテーブル群の直近ハンド履歴を取得します。
+     *
+     * @param tableIds 対象テーブル ID の一覧
+     * @param limit 取得件数の上限
+     * @return 新しい順のハンド履歴一覧
+     */
     List<HandHistoryEntry> findRecentByTableIds(List<String> tableIds, int limit);
 }

--- a/mapoker-backend/src/main/java/com/mapoker/application/HandHistoryService.java
+++ b/mapoker-backend/src/main/java/com/mapoker/application/HandHistoryService.java
@@ -4,6 +4,9 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+/**
+ * Spring の {@code @Service} としてハンド履歴の記録と参照を仲介するサービスです。
+ */
 @Service
 public class HandHistoryService {
 
@@ -19,6 +22,11 @@ public class HandHistoryService {
         this.userTableHistoryService = userTableHistoryService;
     }
 
+    /**
+     * ハンド履歴を記録します。
+     *
+     * @param entry 記録するハンド履歴
+     */
     public void record(HandHistoryEntry entry) {
         if (entry == null || entry.tableId() == null || entry.tableId().isBlank()) {
             return;
@@ -26,10 +34,23 @@ public class HandHistoryService {
         handHistoryRepository.save(entry);
     }
 
+    /**
+     * ユーザーの直近ハンド履歴を既定件数で取得します。
+     *
+     * @param username 対象ユーザー名
+     * @return 直近ハンド履歴の一覧
+     */
     public List<HandHistoryEntry> listRecentForUser(String username) {
         return listRecentForUser(username, DEFAULT_LIMIT);
     }
 
+    /**
+     * ユーザーの直近ハンド履歴を取得します。
+     *
+     * @param username 対象ユーザー名
+     * @param limit 取得件数の上限
+     * @return 直近ハンド履歴の一覧
+     */
     public List<HandHistoryEntry> listRecentForUser(String username, int limit) {
         String normalizedUsername = normalizeUsername(username);
         if (normalizedUsername == null) {

--- a/mapoker-backend/src/main/java/com/mapoker/application/TableMemberRecord.java
+++ b/mapoker-backend/src/main/java/com/mapoker/application/TableMemberRecord.java
@@ -1,5 +1,13 @@
 package com.mapoker.application;
 
+/**
+ * テーブル参加者の表示用情報です。
+ *
+ * @param name 参加者名
+ * @param seatIndex 着席位置
+ * @param joinedAt 参加日時
+ * @param pendingLeave 離席処理待ちかどうか
+ */
 public record TableMemberRecord(
         String name,
         int seatIndex,

--- a/mapoker-backend/src/main/java/com/mapoker/application/TableRecord.java
+++ b/mapoker-backend/src/main/java/com/mapoker/application/TableRecord.java
@@ -3,6 +3,25 @@ package com.mapoker.application;
 import java.time.Instant;
 import java.util.List;
 
+/**
+ * テーブルの設定と状態を表すアプリケーション用レコードです。
+ *
+ * @param id テーブル ID
+ * @param roomId ルーム ID
+ * @param name テーブル名
+ * @param gameType ゲーム種別
+ * @param smallBlind スモールブラインド
+ * @param bigBlind ビッグブラインド
+ * @param minBuyIn 最小バイイン額
+ * @param maxBuyIn 最大バイイン額
+ * @param maxPlayers 最大参加人数
+ * @param flags テーブル属性の一覧
+ * @param visibility 公開設定
+ * @param status テーブル状態
+ * @param gameId 紐づくゲーム ID
+ * @param createdAt 作成日時
+ * @param everSeated 一度でも着席があったかどうか
+ */
 public record TableRecord(
         String id,
         String roomId,

--- a/mapoker-backend/src/main/java/com/mapoker/application/TableService.java
+++ b/mapoker-backend/src/main/java/com/mapoker/application/TableService.java
@@ -19,6 +19,9 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+/**
+ * Spring の {@code @Service} としてテーブル作成、参加管理、ゲーム連携を担うサービスです。
+ */
 @Service
 public class TableService {
 
@@ -45,6 +48,13 @@ public class TableService {
         this.walletServiceProvider = walletServiceProvider;
     }
 
+    /**
+     * リングゲーム用のテーブルを作成します。
+     *
+     * @param input テーブル作成条件
+     * @return 作成されたテーブルとゲーム
+     * @throws IllegalArgumentException 入力値が不正な場合
+     */
     public CreateTableResult createRingTable(CreateRingTableInput input) {
         validateCreateInput(input);
 
@@ -83,10 +93,23 @@ public class TableService {
         return new CreateTableResult(table, game);
     }
 
+    /**
+     * 全テーブルを既定条件で一覧取得します。
+     *
+     * @return テーブル一覧
+     */
     public List<TableRecord> listTables() {
         return listTables(null, null);
     }
 
+    /**
+     * 条件に一致するテーブルを一覧取得します。
+     *
+     * @param visibility 公開設定の絞り込み条件
+     * @param flags 必須フラグの絞り込み条件
+     * @return 条件に一致するテーブル一覧
+     * @throws IllegalArgumentException 公開設定の条件が不正な場合
+     */
     public List<TableRecord> listTables(String visibility, String flags) {
         String visibilityFilter = normalizeVisibilityFilter(visibility);
         List<String> requiredFlags = normalizeFlagFilter(flags);
@@ -102,6 +125,12 @@ public class TableService {
                 .toList();
     }
 
+    /**
+     * 指定 ID のテーブル情報を取得します。
+     *
+     * @param id テーブル ID
+     * @return テーブル情報
+     */
     public TableRecord getTable(String id) {
         TableRecord table = tables.get(id);
         if (table != null) {
@@ -110,22 +139,48 @@ public class TableService {
         return fromGame(gameService.getGame(id));
     }
 
+    /**
+     * 指定テーブルに紐づくゲーム状態を取得します。
+     *
+     * @param id テーブル ID
+     * @return ゲーム状態
+     */
     public GameState getTableGame(String id) {
         return gameService.getGame(getTable(id).gameId());
     }
 
+    /**
+     * 指定テーブルの参加者一覧を取得します。
+     *
+     * @param id テーブル ID
+     * @return 参加者一覧
+     */
     public List<TableMemberRecord> getMembers(String id) {
         TableRecord table = getTable(id);
         tableMembers.putIfAbsent(table.id(), new ArrayList<>());
         return List.copyOf(tableMembers.get(table.id()));
     }
 
+    /**
+     * 指定テーブルで新しいハンドを開始します。
+     *
+     * @param tableId テーブル ID
+     * @param bigBlind ビッグブラインド額
+     * @return 更新後のゲーム状態
+     */
     public GameState startHand(String tableId, int bigBlind) {
         synchronized (tableLock(tableId)) {
             return gameService.startHand(tableId, bigBlind);
         }
     }
 
+    /**
+     * 参加者名から着席位置を検索します。
+     *
+     * @param id テーブル ID
+     * @param memberName 参加者名
+     * @return 見つかった着席位置。見つからない場合は {@code null}
+     */
     public Integer findSeatIndex(String id, String memberName) {
         if (memberName == null || memberName.isBlank()) {
             return null;
@@ -137,6 +192,16 @@ public class TableService {
                 .orElse(null);
     }
 
+    /**
+     * 指定テーブルへ参加者を着席させます。
+     *
+     * @param id テーブル ID
+     * @param requestedName 希望参加者名
+     * @param buyIn バイイン額
+     * @return 割り当てられた席と最新参加者一覧
+     * @throws IllegalArgumentException テーブル満席やバイイン条件違反の場合
+     * @throws IllegalStateException ウォレット残高が不足している場合
+     */
     public JoinResult join(String id, String requestedName, int buyIn) {
         synchronized (tableLock(id)) {
             TableRecord table = getTable(id);
@@ -194,6 +259,14 @@ public class TableService {
         }
     }
 
+    /**
+     * 指定テーブルから参加者を離席させます。
+     *
+     * @param id テーブル ID
+     * @param name 参加者名
+     * @param seatIndex 着席位置
+     * @return 更新後の参加者一覧
+     */
     public List<TableMemberRecord> leave(String id, String name, Integer seatIndex) {
         synchronized (tableLock(id)) {
             TableRecord table = getTable(id);
@@ -234,6 +307,11 @@ public class TableService {
         }
     }
 
+    /**
+     * ハンド終了後に離席待ち参加者を確定処理します。
+     *
+     * @param tableId テーブル ID
+     */
     public void processPendingLeaves(String tableId) {
         synchronized (tableLock(tableId)) {
             TableRecord table = getTable(tableId);
@@ -429,6 +507,16 @@ public class TableService {
         return game.getStatus().getLabel();
     }
 
+    /**
+     * リングテーブル作成時の入力値です。
+     *
+     * @param tableName テーブル名
+     * @param playerCount プレイヤー人数
+     * @param smallBlind スモールブラインド額
+     * @param bigBlind ビッグブラインド額
+     * @param visibility 公開設定
+     * @param flags テーブル属性の一覧
+     */
     public record CreateRingTableInput(
             String tableName,
             int playerCount,
@@ -446,7 +534,19 @@ public class TableService {
         }
     }
 
+    /**
+     * 着席結果を返すレコードです。
+     *
+     * @param assignedSeatIndex 割り当てられた席番号
+     * @param members 更新後の参加者一覧
+     */
     public record JoinResult(int assignedSeatIndex, List<TableMemberRecord> members) {}
 
+    /**
+     * テーブル作成結果を返すレコードです。
+     *
+     * @param table 作成されたテーブル
+     * @param game 作成されたゲーム
+     */
     public record CreateTableResult(TableRecord table, GameState game) {}
 }

--- a/mapoker-backend/src/main/java/com/mapoker/application/User.java
+++ b/mapoker-backend/src/main/java/com/mapoker/application/User.java
@@ -2,4 +2,11 @@ package com.mapoker.application;
 
 import java.time.LocalDateTime;
 
+/**
+ * ユーザーの基本情報を表すレコードです。
+ *
+ * @param id ユーザー ID
+ * @param username ユーザー名
+ * @param createdAt 作成日時
+ */
 public record User(long id, String username, LocalDateTime createdAt) {}

--- a/mapoker-backend/src/main/java/com/mapoker/application/UserRepository.java
+++ b/mapoker-backend/src/main/java/com/mapoker/application/UserRepository.java
@@ -2,8 +2,33 @@ package com.mapoker.application;
 
 import java.util.Optional;
 
+/**
+ * ユーザー情報の永続化を担当するリポジトリです。
+ */
 public interface UserRepository {
+
+    /**
+     * 新しいユーザーを作成します。
+     *
+     * @param username ユーザー名
+     * @param passwordHash ハッシュ化済みパスワード
+     * @return 作成されたユーザー
+     */
     User create(String username, String passwordHash);
+
+    /**
+     * ユーザー名でユーザーを検索します。
+     *
+     * @param username ユーザー名
+     * @return 見つかったユーザー
+     */
     Optional<User> findByUsername(String username);
+
+    /**
+     * ユーザー名でパスワードハッシュを検索します。
+     *
+     * @param username ユーザー名
+     * @return 見つかったパスワードハッシュ
+     */
     Optional<String> findPasswordHashByUsername(String username);
 }

--- a/mapoker-backend/src/main/java/com/mapoker/application/UserService.java
+++ b/mapoker-backend/src/main/java/com/mapoker/application/UserService.java
@@ -9,6 +9,9 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+/**
+ * Spring の {@code @Service} としてユーザー登録と認証用ユーザー解決を担当するサービスです。
+ */
 @Service
 public class UserService implements UserDetailsService {
 
@@ -24,6 +27,14 @@ public class UserService implements UserDetailsService {
         this.walletServiceProvider = walletServiceProvider;
     }
 
+    /**
+     * 新しいユーザーを登録します。
+     *
+     * @param username ユーザー名
+     * @param password 平文パスワード
+     * @return 作成されたユーザー
+     * @throws IllegalArgumentException ユーザー名が既に使用されている場合
+     */
     public User register(String username, String password) {
         String normalizedUsername = normalizeUsername(username);
         if (userRepository.findByUsername(normalizedUsername).isPresent()) {
@@ -37,12 +48,26 @@ public class UserService implements UserDetailsService {
         return createdUser;
     }
 
+    /**
+     * ユーザー名からユーザー情報を取得します。
+     *
+     * @param username ユーザー名
+     * @return 対応するユーザー
+     * @throws UsernameNotFoundException ユーザーが存在しない場合
+     */
     public User getByUsername(String username) {
         String normalizedUsername = normalizeUsername(username);
         return userRepository.findByUsername(normalizedUsername)
                 .orElseThrow(() -> new UsernameNotFoundException("User not found: " + normalizedUsername));
     }
 
+    /**
+     * 認証処理用にユーザー詳細を読み込みます。
+     *
+     * @param username ユーザー名
+     * @return 認証に利用するユーザー詳細
+     * @throws UsernameNotFoundException ユーザーが存在しない場合
+     */
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         String normalizedUsername = normalizeUsername(username);

--- a/mapoker-backend/src/main/java/com/mapoker/application/UserTableHistoryEntry.java
+++ b/mapoker-backend/src/main/java/com/mapoker/application/UserTableHistoryEntry.java
@@ -3,6 +3,19 @@ package com.mapoker.application;
 import java.time.Instant;
 import java.util.List;
 
+/**
+ * ユーザーごとのテーブル参加履歴を表すレコードです。
+ *
+ * @param username ユーザー名
+ * @param tableId テーブル ID
+ * @param tableName テーブル名
+ * @param seatIndex 着席位置
+ * @param visibility 公開設定
+ * @param status テーブル状態
+ * @param flags テーブル属性の一覧
+ * @param joinedAt 参加日時
+ * @param leftAt 退出日時
+ */
 public record UserTableHistoryEntry(
         String username,
         String tableId,
@@ -18,6 +31,11 @@ public record UserTableHistoryEntry(
         flags = flags == null ? List.of() : List.copyOf(flags);
     }
 
+    /**
+     * 参加履歴が現在も有効かを返します。
+     *
+     * @return 退出日時が未設定なら {@code true}
+     */
     public boolean active() {
         return leftAt == null;
     }

--- a/mapoker-backend/src/main/java/com/mapoker/application/UserTableHistoryRepository.java
+++ b/mapoker-backend/src/main/java/com/mapoker/application/UserTableHistoryRepository.java
@@ -2,11 +2,35 @@ package com.mapoker.application;
 
 import java.util.List;
 
+/**
+ * ユーザーのテーブル参加履歴を扱うリポジトリです。
+ */
 public interface UserTableHistoryRepository {
 
+    /**
+     * テーブル参加を履歴として記録します。
+     *
+     * @param username ユーザー名
+     * @param table 参加したテーブル
+     * @param seatIndex 着席位置
+     */
     void recordJoin(String username, TableRecord table, int seatIndex);
 
+    /**
+     * テーブル退出を履歴として記録します。
+     *
+     * @param username ユーザー名
+     * @param tableId テーブル ID
+     * @param seatIndex 着席位置
+     */
     void recordLeave(String username, String tableId, Integer seatIndex);
 
+    /**
+     * ユーザーの直近参加履歴を取得します。
+     *
+     * @param username ユーザー名
+     * @param limit 取得件数の上限
+     * @return 参加履歴一覧
+     */
     List<UserTableHistoryEntry> findRecentByUsername(String username, int limit);
 }

--- a/mapoker-backend/src/main/java/com/mapoker/application/UserTableHistoryService.java
+++ b/mapoker-backend/src/main/java/com/mapoker/application/UserTableHistoryService.java
@@ -4,6 +4,9 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+/**
+ * Spring の {@code @Service} としてユーザーのテーブル参加履歴を管理するサービスです。
+ */
 @Service
 public class UserTableHistoryService {
 
@@ -15,6 +18,13 @@ public class UserTableHistoryService {
         this.historyRepository = historyRepository;
     }
 
+    /**
+     * テーブル参加を履歴へ記録します。
+     *
+     * @param username ユーザー名
+     * @param table 参加テーブル
+     * @param seatIndex 着席位置
+     */
     public void recordJoin(String username, TableRecord table, int seatIndex) {
         String normalizedUsername = normalizeUsername(username);
         if (normalizedUsername == null) {
@@ -23,6 +33,13 @@ public class UserTableHistoryService {
         historyRepository.recordJoin(normalizedUsername, table, seatIndex);
     }
 
+    /**
+     * テーブル退出を履歴へ記録します。
+     *
+     * @param username ユーザー名
+     * @param tableId テーブル ID
+     * @param seatIndex 着席位置
+     */
     public void recordLeave(String username, String tableId, Integer seatIndex) {
         String normalizedUsername = normalizeUsername(username);
         if (normalizedUsername == null || tableId == null || tableId.isBlank()) {
@@ -31,10 +48,23 @@ public class UserTableHistoryService {
         historyRepository.recordLeave(normalizedUsername, tableId, seatIndex);
     }
 
+    /**
+     * 既定件数で直近参加履歴を取得します。
+     *
+     * @param username ユーザー名
+     * @return 直近参加履歴一覧
+     */
     public List<UserTableHistoryEntry> listRecent(String username) {
         return listRecent(username, DEFAULT_HISTORY_LIMIT);
     }
 
+    /**
+     * 直近参加履歴を取得します。
+     *
+     * @param username ユーザー名
+     * @param limit 取得件数の上限
+     * @return 直近参加履歴一覧
+     */
     public List<UserTableHistoryEntry> listRecent(String username, int limit) {
         String normalizedUsername = normalizeUsername(username);
         if (normalizedUsername == null) {

--- a/mapoker-backend/src/main/java/com/mapoker/application/WalletEntry.java
+++ b/mapoker-backend/src/main/java/com/mapoker/application/WalletEntry.java
@@ -2,6 +2,13 @@ package com.mapoker.application;
 
 import java.time.Instant;
 
+/**
+ * ユーザーウォレット残高を表すレコードです。
+ *
+ * @param username ユーザー名
+ * @param chipBalance チップ残高
+ * @param updatedAt 最終更新日時
+ */
 public record WalletEntry(
         String username,
         long chipBalance,

--- a/mapoker-backend/src/main/java/com/mapoker/application/WalletLedgerEntry.java
+++ b/mapoker-backend/src/main/java/com/mapoker/application/WalletLedgerEntry.java
@@ -2,6 +2,18 @@ package com.mapoker.application;
 
 import java.time.Instant;
 
+/**
+ * ウォレット台帳の 1 件を表すレコードです。
+ *
+ * @param id 台帳 ID
+ * @param username ユーザー名
+ * @param delta 増減量
+ * @param balanceAfter 反映後残高
+ * @param reason 取引理由
+ * @param referenceType 参照種別
+ * @param referenceId 参照 ID
+ * @param createdAt 作成日時
+ */
 public record WalletLedgerEntry(
         long id,
         String username,

--- a/mapoker-backend/src/main/java/com/mapoker/application/WalletRepository.java
+++ b/mapoker-backend/src/main/java/com/mapoker/application/WalletRepository.java
@@ -4,17 +4,66 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * ウォレット残高と台帳を永続化するリポジトリです。
+ */
 public interface WalletRepository {
 
+    /**
+     * ユーザー用ウォレットを初期化します。
+     *
+     * @param username ユーザー名
+     */
     void initializeWallet(String username);
 
+    /**
+     * ユーザー名からウォレット情報を取得します。
+     *
+     * @param username ユーザー名
+     * @return ウォレット情報
+     */
     Optional<WalletEntry> findByUsername(String username);
 
+    /**
+     * 指定額を出金します。
+     *
+     * @param username ユーザー名
+     * @param amount 出金額
+     * @param reason 取引理由
+     * @param refType 参照種別
+     * @param refId 参照 ID
+     * @param idempotencyKey 冪等性キー
+     * @return 出金に成功した場合は {@code true}
+     */
     boolean debit(String username, long amount, String reason, String refType, String refId, String idempotencyKey);
 
+    /**
+     * 指定額を入金します。
+     *
+     * @param username ユーザー名
+     * @param amount 入金額
+     * @param reason 取引理由
+     * @param refType 参照種別
+     * @param refId 参照 ID
+     * @param idempotencyKey 冪等性キー
+     */
     void credit(String username, long amount, String reason, String refType, String refId, String idempotencyKey);
 
+    /**
+     * 直近の台帳履歴を取得します。
+     *
+     * @param username ユーザー名
+     * @param limit 取得件数の上限
+     * @return 台帳履歴一覧
+     */
     List<WalletLedgerEntry> findLedger(String username, int limit);
 
+    /**
+     * 指定理由の最終台帳時刻を取得します。
+     *
+     * @param username ユーザー名
+     * @param reason 取引理由
+     * @return 最終台帳時刻
+     */
     Optional<Instant> findLastLedgerTime(String username, String reason);
 }

--- a/mapoker-backend/src/main/java/com/mapoker/application/WalletService.java
+++ b/mapoker-backend/src/main/java/com/mapoker/application/WalletService.java
@@ -9,6 +9,9 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 
+/**
+ * Spring の {@code @Service} としてウォレット残高、入出金、ボーナス付与を管理するサービスです。
+ */
 @Service
 @Profile("postgresql")
 public class WalletService {
@@ -27,10 +30,22 @@ public class WalletService {
         this.walletProperties = walletProperties;
     }
 
+    /**
+     * ユーザーのウォレットを初期化します。
+     *
+     * @param username ユーザー名
+     * @throws IllegalArgumentException ユーザー名が不正な場合
+     */
     public void initializeWallet(String username) {
         walletRepository.initializeWallet(requireUsername(username));
     }
 
+    /**
+     * 現在の残高を取得します。
+     *
+     * @param username ユーザー名
+     * @return ウォレット残高情報
+     */
     public WalletEntry getBalance(String username) {
         String normalizedUsername = normalizeUsername(username);
         if (normalizedUsername == null) {
@@ -40,6 +55,13 @@ public class WalletService {
                 .orElseGet(() -> new WalletEntry(normalizedUsername, 0L, null));
     }
 
+    /**
+     * 台帳履歴を取得します。
+     *
+     * @param username ユーザー名
+     * @param limit 取得件数の上限
+     * @return 台帳履歴一覧
+     */
     public List<WalletLedgerEntry> getLedger(String username, int limit) {
         String normalizedUsername = normalizeUsername(username);
         if (normalizedUsername == null) {
@@ -48,6 +70,12 @@ public class WalletService {
         return walletRepository.findLedger(normalizedUsername, Math.max(1, limit));
     }
 
+    /**
+     * 次回請求可能時刻を取得します。
+     *
+     * @param username ユーザー名
+     * @return 日次ボーナスと救済ボーナスの次回可能時刻
+     */
     public NextClaimTimes getNextClaimTimes(String username) {
         String normalizedUsername = normalizeUsername(username);
         if (normalizedUsername == null) {
@@ -59,6 +87,15 @@ public class WalletService {
                 nextRecoveryAt(normalizedUsername, wallet));
     }
 
+    /**
+     * テーブル参加のためにウォレットからチップを引き落とします。
+     *
+     * @param username ユーザー名
+     * @param tableId テーブル ID
+     * @param amount 引き落とし額
+     * @throws IllegalArgumentException 入力値が不正な場合
+     * @throws IllegalStateException 残高不足の場合
+     */
     public void buyIn(String username, String tableId, int amount) {
         String normalizedUsername = requireUsername(username);
         String normalizedTableId = normalizeReference(tableId);
@@ -74,6 +111,14 @@ public class WalletService {
         }
     }
 
+    /**
+     * テーブルからの持ち帰りチップをウォレットへ戻します。
+     *
+     * @param username ユーザー名
+     * @param tableId テーブル ID
+     * @param amount 入金額
+     * @throws IllegalArgumentException 入力値が不正な場合
+     */
     public void cashOut(String username, String tableId, int amount) {
         String normalizedUsername = requireUsername(username);
         String normalizedTableId = normalizeReference(tableId);
@@ -87,6 +132,13 @@ public class WalletService {
                 "CASH_OUT:" + normalizedTableId + ":" + normalizedUsername + ":" + amount);
     }
 
+    /**
+     * 日次ボーナスを付与します。
+     *
+     * @param username ユーザー名
+     * @throws IllegalArgumentException ユーザー名が不正な場合
+     * @throws IllegalStateException クールダウン中の場合
+     */
     public void claimDailyBonus(String username) {
         String normalizedUsername = requireUsername(username);
         requireCooldownElapsed(
@@ -102,6 +154,13 @@ public class WalletService {
                 "DAILY_BONUS:" + normalizedUsername + ":" + currentWindow(walletProperties.dailyBonusCooldownHours()));
     }
 
+    /**
+     * 救済ボーナスを付与します。
+     *
+     * @param username ユーザー名
+     * @throws IllegalArgumentException ユーザー名が不正な場合
+     * @throws IllegalStateException 条件未達またはクールダウン中の場合
+     */
     public void claimRecovery(String username) {
         String normalizedUsername = requireUsername(username);
         WalletEntry wallet = getBalance(normalizedUsername);
@@ -121,6 +180,15 @@ public class WalletService {
                 "RECOVERY_BONUS:" + normalizedUsername + ":" + currentWindow(walletProperties.recoveryCooldownHours()));
     }
 
+    /**
+     * 管理者権限で残高を付与します。
+     *
+     * @param adminUsername 管理者ユーザー名
+     * @param targetUsername 付与対象ユーザー名
+     * @param amount 付与額
+     * @throws IllegalArgumentException 入力値が不正な場合
+     * @throws AccessDeniedException 管理者権限がない場合
+     */
     public void adminGrant(String adminUsername, String targetUsername, long amount) {
         String normalizedAdminUsername = requireUsername(adminUsername);
         String normalizedTargetUsername = requireUsername(targetUsername);
@@ -194,6 +262,12 @@ public class WalletService {
         }
     }
 
+    /**
+     * 次回請求可能時刻をまとめて返すレコードです。
+     *
+     * @param nextDailyBonusAt 日次ボーナスの次回請求可能時刻
+     * @param nextRecoveryAt 救済ボーナスの次回請求可能時刻
+     */
     public record NextClaimTimes(
             Instant nextDailyBonusAt,
             Instant nextRecoveryAt

--- a/mapoker-backend/src/main/java/com/mapoker/domain/PokerConstants.java
+++ b/mapoker-backend/src/main/java/com/mapoker/domain/PokerConstants.java
@@ -1,32 +1,58 @@
 package com.mapoker.domain;
 
-/** Texas Hold'em のルールとして固定された定数。設定ファイルに出してはいけない。 */
+/**
+ * Texas Hold'em のルールとして固定された定数。
+ *
+ * <p>ポーカールール固有の値はここに一元管理する。環境依存の設定（デフォルトのビッグブラインド額など）は
+ * {@code application.properties} で管理し、このクラスには含めない。
+ * ルール変更がない限りこのクラスの値は変更しないこと。
+ */
 public final class PokerConstants {
 
     private PokerConstants() {}
 
+    /** テーブルに参加できる最小プレイヤー数。2人未満ではハンドを開始できない。 */
     public static final int MIN_PLAYERS = 2;
+
+    /** テーブルに参加できる最大プレイヤー数。 */
     public static final int MAX_PLAYERS = 9;
 
+    /** 標準デッキのカード枚数（4スーツ × 13ランク）。 */
     public static final int DECK_SIZE = 52;
+
+    /** スーツの種類数。フラッシュ判定用の配列サイズに使用する。 */
     public static final int NUM_SUITS = 4;
-    /** Rank 値の配列インデックス上限（Ace = 14、0-1 は未使用）*/
+
+    /**
+     * ランク値を配列インデックスとして使う際の配列サイズ。
+     * Ace = 14 なので 15 を確保し、インデックス 0・1 は未使用となる。
+     */
     public static final int RANK_ARRAY_SIZE = 15;
 
+    /** 各プレイヤーに配るホールカードの枚数。 */
     public static final int HOLE_CARDS = 2;
+
+    /** ボードに公開されるコミュニティカードの合計枚数（フロップ3 + ターン1 + リバー1）。 */
     public static final int COMMUNITY_CARDS = 5;
-    /** ハンド評価に使う 7 枚（ホール 2 + コミュニティ 5）*/
+
+    /** ハンド評価に使う 7 枚（ホール 2 + コミュニティ 5）。{@link com.mapoker.domain.hand.HandEvaluator#eval7} が全組み合わせを評価する。 */
     public static final int TOTAL_EVAL_CARDS = 7;
-    /** 1 ハンドを構成するカード枚数（5 枚評価）*/
+
+    /** 1 ハンドを構成するカード枚数（5 枚評価）。{@link com.mapoker.domain.hand.HandEvaluator#eval5} の入力サイズ。 */
     public static final int HAND_SIZE = 5;
-    /** フロップで公開するカード枚数 */
+
+    /** フロップで一度に公開するカード枚数。 */
     public static final int FLOP_CARDS = 3;
 
-    /** フラッシュ判定に必要な同スーツ枚数 */
+    /** フラッシュ成立に必要な同スーツのカード枚数。 */
     public static final int FLUSH_SIZE = 5;
-    /** ストレートを構成する連続ランク枚数 */
+
+    /** ストレート成立に必要な連続するランクの枚数。 */
     public static final int STRAIGHT_LENGTH = 5;
 
-    /** スモールブラインドはビッグブラインドを 2 で割った値 */
+    /**
+     * スモールブラインド額を算出する除数。
+     * スモールブラインド = ビッグブラインド / {@code SMALL_BLIND_DIVISOR}。
+     */
     public static final int SMALL_BLIND_DIVISOR = 2;
 }

--- a/mapoker-backend/src/main/java/com/mapoker/domain/card/Card.java
+++ b/mapoker-backend/src/main/java/com/mapoker/domain/card/Card.java
@@ -3,8 +3,24 @@ package com.mapoker.domain.card;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+/**
+ * トランプ1枚を表す値オブジェクト。
+ *
+ * <p>文字列表現（コード）は {@code "<rank><suit>"} 形式で、例えばスペードのエースは {@code "AS"}、
+ * ハートの10は {@code "TH"}。Jackson シリアライズ／デシリアライズはこのコード形式を使う。
+ */
 public record Card(Rank rank, Suit suit) {
 
+    /**
+     * 文字列コードから {@link Card} を生成する。Jackson の {@code @JsonCreator} として使用される。
+     *
+     * <p>コード形式は {@code "<rank><suit>"}（2〜3文字）。
+     * 例: {@code "AS"}（スペードのエース）、{@code "TH"}（ハートの10）、{@code "10D"}（ダイヤの10）。
+     *
+     * @param code カードを表す文字列（2〜3文字）
+     * @return パースされた {@link Card}
+     * @throws IllegalArgumentException コードが {@code null} または長さが不正な場合
+     */
     @JsonCreator
     public static Card parse(String code) {
         if (code == null || code.length() < 2 || code.length() > 3) {
@@ -15,6 +31,11 @@ public record Card(Rank rank, Suit suit) {
         return new Card(Rank.fromCode(rankPart), Suit.fromCode(suitPart));
     }
 
+    /**
+     * このカードの文字列コードを返す。Jackson の {@code @JsonValue} として使用される。
+     *
+     * @return {@code "<rank><suit>"} 形式の文字列（例: {@code "AS"}、{@code "TH"}）
+     */
     @JsonValue
     public String toCode() {
         return rank.getCode() + suit.getCode();

--- a/mapoker-backend/src/main/java/com/mapoker/domain/card/Deck.java
+++ b/mapoker-backend/src/main/java/com/mapoker/domain/card/Deck.java
@@ -7,10 +7,25 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 
+/**
+ * 標準52枚デッキの生成とシャッフルを担うユーティリティクラス。
+ *
+ * <p>インスタンス化不可。ハンド開始前に {@link #newDeck()} で新しいデッキを生成し、
+ * {@link #shuffle(List, Random)} でシャッフルしてから使う。
+ * デッキはリストとして扱い、先頭から順に1枚ずつドローする（{@link GameState} 内の {@code deckPos} で管理）。
+ */
 public final class Deck {
 
     private Deck() {}
 
+    /**
+     * 全4スーツ × 全13ランクの52枚を含む新しいデッキを生成する。
+     *
+     * <p>返されるリストは可変であり、{@link #shuffle(List, Random)} に直接渡せる。
+     * 順序はスーツ優先でランクが昇順（{@link Suit#values()} × {@link Rank#values()} の順）。
+     *
+     * @return 52枚のカードリスト（シャッフル前）
+     */
     public static List<Card> newDeck() {
         List<Card> deck = new ArrayList<>(PokerConstants.DECK_SIZE);
         for (Suit suit : Suit.values()) {
@@ -21,6 +36,15 @@ public final class Deck {
         return deck;
     }
 
+    /**
+     * 指定した {@link Random} を使ってデッキをシャッフルする。
+     *
+     * <p>{@code rng} が {@code null} の場合は {@code new Random()} をフォールバックとして使う。
+     * 再現性が必要なテストでは非 {@code null} の {@link Random} を渡すこと。
+     *
+     * @param deck シャッフル対象のカードリスト（インプレースで変更される）
+     * @param rng  乱数生成器。{@code null} を渡すとデフォルトの {@link Random} が使われる
+     */
     public static void shuffle(List<Card> deck, Random rng) {
         if (rng == null) {
             rng = new Random();

--- a/mapoker-backend/src/main/java/com/mapoker/domain/card/Rank.java
+++ b/mapoker-backend/src/main/java/com/mapoker/domain/card/Rank.java
@@ -3,6 +3,14 @@ package com.mapoker.domain.card;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+/**
+ * トランプのランク（数字・絵柄）を表す列挙型。
+ *
+ * <p>各定数は数値({@code value})と文字コード({@code code})を持つ。
+ * 数値はハンド強さ比較および配列インデックスとして使用する（2〜14）。
+ * エースは {@code 14} として扱い、ホイール（A-2-3-4-5）のストレートは
+ * {@link com.mapoker.domain.hand.HandEvaluator} 内で特別処理する。
+ */
 public enum Rank {
     TWO(2, "2"), THREE(3, "3"), FOUR(4, "4"), FIVE(5, "5"),
     SIX(6, "6"), SEVEN(7, "7"), EIGHT(8, "8"), NINE(9, "9"),
@@ -16,15 +24,36 @@ public enum Rank {
         this.code = code;
     }
 
+    /**
+     * ハンド強さ比較や配列インデックスとして使う数値を返す。
+     * 2〜14 の範囲で、エースは 14。
+     *
+     * @return ランクの数値（2〜14）
+     */
     public int getValue() {
         return value;
     }
 
+    /**
+     * JSON シリアライズおよびカードコード文字列で使う1文字のコードを返す。
+     * 10 は {@code "T"} として表現される。
+     *
+     * @return ランクの文字コード（例: {@code "A"}、{@code "T"}、{@code "2"}）
+     */
     @JsonValue
     public String getCode() {
         return code;
     }
 
+    /**
+     * 文字コードから {@link Rank} を返す。Jackson の {@code @JsonCreator} として使用される。
+     *
+     * <p>{@code "10"} および大文字小文字を区別せず {@code "t"} はいずれも {@link #TEN} に対応する。
+     *
+     * @param code ランクを表す文字列（例: {@code "A"}、{@code "T"}、{@code "10"}）
+     * @return 対応する {@link Rank}
+     * @throws IllegalArgumentException 不明なコードの場合
+     */
     @JsonCreator
     public static Rank fromCode(String code) {
         if ("10".equals(code) || "t".equalsIgnoreCase(code)) return TEN;
@@ -34,6 +63,13 @@ public enum Rank {
         throw new IllegalArgumentException("Unknown rank: " + code);
     }
 
+    /**
+     * 数値から {@link Rank} を返す。ハンド評価器内部での逆引きに使用する。
+     *
+     * @param value ランクの数値（2〜14）
+     * @return 対応する {@link Rank}
+     * @throws IllegalArgumentException 対応するランクが存在しない場合
+     */
     public static Rank fromValue(int value) {
         for (Rank r : values()) {
             if (r.value == value) return r;

--- a/mapoker-backend/src/main/java/com/mapoker/domain/card/Suit.java
+++ b/mapoker-backend/src/main/java/com/mapoker/domain/card/Suit.java
@@ -3,6 +3,13 @@ package com.mapoker.domain.card;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+/**
+ * トランプのスーツ（マーク）を表す列挙型。
+ *
+ * <p>各定数は1文字のコード（{@code "S"}/{@code "H"}/{@code "D"}/{@code "C"}）を持つ。
+ * フラッシュ判定では {@code ordinal()} を配列インデックスとして使うため、
+ * 定数の順序を変更しないこと。
+ */
 public enum Suit {
     SPADES("S"), HEARTS("H"), DIAMONDS("D"), CLUBS("C");
 
@@ -12,11 +19,24 @@ public enum Suit {
         this.code = code;
     }
 
+    /**
+     * JSON シリアライズおよびカードコード文字列で使う1文字のコードを返す。
+     *
+     * @return スーツの文字コード（{@code "S"}、{@code "H"}、{@code "D"}、{@code "C"} のいずれか）
+     */
     @JsonValue
     public String getCode() {
         return code;
     }
 
+    /**
+     * 文字コードから {@link Suit} を返す。大文字小文字を区別しない。
+     * Jackson の {@code @JsonCreator} として使用される。
+     *
+     * @param code スーツを表す文字列（例: {@code "S"}、{@code "h"}）
+     * @return 対応する {@link Suit}
+     * @throws IllegalArgumentException 不明なコードの場合
+     */
     @JsonCreator
     public static Suit fromCode(String code) {
         for (Suit s : values()) {

--- a/mapoker-backend/src/main/java/com/mapoker/domain/game/GameState.java
+++ b/mapoker-backend/src/main/java/com/mapoker/domain/game/GameState.java
@@ -19,6 +19,29 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 
+/**
+ * Texas Hold'em 1ゲームの進行状態をすべて保持するドメインオブジェクト。
+ *
+ * <p>このクラスはゲームのコアロジック（ブラインド投下・アクション適用・ストリート進行・
+ * サイドポット分配・ショーダウン解決）を担う。Spring 非依存の純粋 Java クラス。
+ *
+ * <h2>ライフサイクル</h2>
+ * <ol>
+ *   <li>{@link #newGame} でゲームインスタンスを生成する</li>
+ *   <li>{@link #startHand} で各ハンドを開始（ブラインド投下・カード配布）する</li>
+ *   <li>{@link #applyAction} でプレイヤーのアクションを適用する（バリデーション含む）</li>
+ *   <li>ストリートが進み {@code status == SHOWDOWN} になったら {@link #resolveShowdown} を呼ぶ</li>
+ *   <li>{@link #applyPayouts} でポットを配分し、ステータスが {@code FINISHED} になる</li>
+ * </ol>
+ *
+ * <h2>制約</h2>
+ * <ul>
+ *   <li>{@code bet}/{@code raise} の {@code amount} は増分ではなく合計額（raise-to total）</li>
+ *   <li>最小レイズ = {@code max(bigBlind, lastRaiseSize)}。サブミニオールインは許容するが
+ *       {@code raiseOpen=false} にしてベッティングを再オープンしない</li>
+ *   <li>奇数チップの端数配分は {@link OddChipRule} で制御する</li>
+ * </ul>
+ */
 public class GameState {
 
     private String id;
@@ -44,10 +67,30 @@ public class GameState {
 
     private GameState() {}
 
+    /**
+     * 永続化からの復元専用の空インスタンスを生成する。
+     * リポジトリ実装がデシリアライズ後に各フィールドをセッターで埋める用途に限定する。
+     *
+     * @return フィールド未設定の空 {@link GameState}
+     */
     public static GameState empty() {
         return new GameState();
     }
 
+    /**
+     * 新しいゲームインスタンスを生成する。プレイヤーリストはディープコピーされる。
+     *
+     * <p>このメソッドはデッキの生成とシャッフルのみを行い、ブラインド投下やカード配布は
+     * 行わない。ハンドを開始するには別途 {@link #startHand} を呼ぶこと。
+     *
+     * @param players     参加プレイヤーのリスト（2〜9人）
+     * @param buttonIndex ボタン位置（プレイヤーリストの 0-based インデックス）
+     * @param bigBlind    ビッグブラインド額（正の値）
+     * @param rng         シャッフル用乱数生成器。{@code null} の場合はデフォルト {@link Random}
+     * @param oddChipRule 奇数チップの配分ルール。{@code null} の場合は {@link OddChipRule#LOW_INDEX}
+     * @return 初期化済みの {@link GameState}
+     * @throws IllegalArgumentException プレイヤー数・ビッグブラインド額・ボタン位置が不正な場合
+     */
     public static GameState newGame(List<Player> players, int buttonIndex, int bigBlind, Random rng, OddChipRule oddChipRule) {
         if (players.size() < PokerConstants.MIN_PLAYERS || players.size() > PokerConstants.MAX_PLAYERS)
             throw new IllegalArgumentException("players must be 2-9");
@@ -74,6 +117,16 @@ public class GameState {
         return g;
     }
 
+    /**
+     * 新しいハンドを開始する。ボタンを次のアクティブプレイヤーに進め、ブラインドを投下し、
+     * 各プレイヤーにホールカードを2枚配布する。
+     *
+     * <p>チップが0のプレイヤーは自動的にフォールド扱いになる。
+     * ヘッズアップ（2人）のときはボタン = スモールブラインドとなる（ポーカールール準拠）。
+     *
+     * @param bigBlind ビッグブラインド額
+     * @throws IllegalStateException ショーダウンが未解決の場合、またはチップ保有者が2人未満の場合
+     */
     public void startHand(int bigBlind) {
         if (status == GameStatus.SHOWDOWN)
             throw new IllegalStateException("cannot start hand: showdown not resolved");

--- a/mapoker-backend/src/main/java/com/mapoker/domain/game/GameStatus.java
+++ b/mapoker-backend/src/main/java/com/mapoker/domain/game/GameStatus.java
@@ -2,9 +2,15 @@ package com.mapoker.domain.game;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+/**
+ * ゲーム進行状態を表す列挙型です。
+ */
 public enum GameStatus {
+    /** ハンド進行中です。 */
     IN_PROGRESS("in_progress"),
+    /** ショーダウン処理中です。 */
     SHOWDOWN("showdown"),
+    /** ハンドが終了しています。 */
     FINISHED("finished");
 
     private final String label;

--- a/mapoker-backend/src/main/java/com/mapoker/domain/game/OddChipRule.java
+++ b/mapoker-backend/src/main/java/com/mapoker/domain/game/OddChipRule.java
@@ -3,8 +3,13 @@ package com.mapoker.domain.game;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+/**
+ * 端数チップの配分ルールを表す列挙型です。
+ */
 public enum OddChipRule {
+    /** 席番号が小さい順に配分します。 */
     LOW_INDEX("low_index"),
+    /** ボタン左隣から配分します。 */
     BUTTON_LEFT("button_left");
 
     private final String label;
@@ -18,6 +23,13 @@ public enum OddChipRule {
         return label;
     }
 
+    /**
+     * ラベルから端数チップルールを解決します。
+     *
+     * @param label ルールラベル
+     * @return 対応する端数チップルール
+     * @throws IllegalArgumentException 未知のラベルが指定された場合
+     */
     @JsonCreator
     public static OddChipRule fromLabel(String label) {
         for (OddChipRule r : values()) {

--- a/mapoker-backend/src/main/java/com/mapoker/domain/game/Player.java
+++ b/mapoker-backend/src/main/java/com/mapoker/domain/game/Player.java
@@ -2,6 +2,9 @@ package com.mapoker.domain.game;
 
 import com.mapoker.domain.card.Card;
 
+/**
+ * ゲーム内プレイヤーの可変状態を保持するドメインオブジェクトです。
+ */
 public class Player {
     private String id;
     private int stack;
@@ -12,6 +15,12 @@ public class Player {
     private int contributed;
     private int totalContrib;
 
+    /**
+     * 新しいプレイヤーを生成します。
+     *
+     * @param id プレイヤー ID
+     * @param stack 初期スタック額
+     */
     public Player(String id, int stack) {
         this.id = id;
         this.stack = stack;
@@ -23,7 +32,11 @@ public class Player {
         this.totalContrib = 0;
     }
 
-    // copy constructor
+    /**
+     * コピーコンストラクタです。ホールカード配列はディープコピーします。
+     *
+     * @param other コピー元プレイヤー
+     */
     public Player(Player other) {
         this.id = other.id;
         this.stack = other.stack;

--- a/mapoker-backend/src/main/java/com/mapoker/domain/game/ShowdownResult.java
+++ b/mapoker-backend/src/main/java/com/mapoker/domain/game/ShowdownResult.java
@@ -3,4 +3,11 @@ package com.mapoker.domain.game;
 import com.mapoker.domain.hand.HandValue;
 import java.util.List;
 
+/**
+ * ショーダウン結果を表すレコードです。
+ *
+ * @param winnerIndexes 勝者の席番号一覧
+ * @param bestHand 勝利ハンドの内容
+ * @param payouts 各勝者への配当一覧
+ */
 public record ShowdownResult(List<Integer> winnerIndexes, HandValue bestHand, List<Integer> payouts) {}

--- a/mapoker-backend/src/main/java/com/mapoker/domain/hand/HandEvaluator.java
+++ b/mapoker-backend/src/main/java/com/mapoker/domain/hand/HandEvaluator.java
@@ -9,10 +9,19 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * ポーカーハンドの役判定を行うユーティリティです。
+ */
 public final class HandEvaluator {
 
     private HandEvaluator() {}
 
+    /**
+     * 5 枚のカードから役を評価します。
+     *
+     * @param cards 評価対象の 5 枚カード
+     * @return 評価結果
+     */
     public static HandValue eval5(Card[] cards) {
         int[] rankCounts = new int[PokerConstants.RANK_ARRAY_SIZE];
         int[] suitCounts = new int[PokerConstants.NUM_SUITS];
@@ -66,6 +75,12 @@ public final class HandEvaluator {
         return new HandValue(HandRank.HIGH_CARD, ranksDesc(rankCounts));
     }
 
+    /**
+     * 7 枚のカードから最良の 5 枚役を評価します。
+     *
+     * @param cards 評価対象の 7 枚カード
+     * @return 最良役の評価結果
+     */
     public static HandValue eval7(Card[] cards) {
         HandValue best = new HandValue(HandRank.HIGH_CARD, List.of(Rank.TWO));
         Card[] combo = new Card[5];

--- a/mapoker-backend/src/main/java/com/mapoker/domain/hand/HandRank.java
+++ b/mapoker-backend/src/main/java/com/mapoker/domain/hand/HandRank.java
@@ -3,15 +3,27 @@ package com.mapoker.domain.hand;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+/**
+ * ポーカーハンドの役を表す列挙型です。
+ */
 public enum HandRank {
+    /** ハイカードです。 */
     HIGH_CARD("HighCard"),
+    /** ワンペアです。 */
     ONE_PAIR("OnePair"),
+    /** ツーペアです。 */
     TWO_PAIR("TwoPair"),
+    /** スリーカードです。 */
     THREE_OF_A_KIND("ThreeOfAKind"),
+    /** ストレートです。 */
     STRAIGHT("Straight"),
+    /** フラッシュです。 */
     FLUSH("Flush"),
+    /** フルハウスです。 */
     FULL_HOUSE("FullHouse"),
+    /** フォーカードです。 */
     FOUR_OF_A_KIND("FourOfAKind"),
+    /** ストレートフラッシュです。 */
     STRAIGHT_FLUSH("StraightFlush");
 
     private final String label;
@@ -25,6 +37,13 @@ public enum HandRank {
         return label;
     }
 
+    /**
+     * ラベルから役を解決します。
+     *
+     * @param label 役ラベル
+     * @return 対応する役
+     * @throws IllegalArgumentException 未知のラベルが指定された場合
+     */
     @JsonCreator
     public static HandRank fromLabel(String label) {
         for (HandRank h : values()) {

--- a/mapoker-backend/src/main/java/com/mapoker/domain/hand/HandValue.java
+++ b/mapoker-backend/src/main/java/com/mapoker/domain/hand/HandValue.java
@@ -3,8 +3,20 @@ package com.mapoker.domain.hand;
 import com.mapoker.domain.card.Rank;
 import java.util.List;
 
+/**
+ * 役とキッカー情報を保持するレコードです。
+ *
+ * @param rank 役
+ * @param kickers 比較用のランク一覧
+ */
 public record HandValue(HandRank rank, List<Rank> kickers) {
 
+    /**
+     * 別の役と強さを比較します。
+     *
+     * @param other 比較対象の役
+     * @return この役が強ければ正、弱ければ負、同値なら 0
+     */
     public int compareTo(HandValue other) {
         if (this.rank != other.rank) {
             return this.rank.ordinal() - other.rank.ordinal();

--- a/mapoker-backend/src/main/java/com/mapoker/domain/rules/Action.java
+++ b/mapoker-backend/src/main/java/com/mapoker/domain/rules/Action.java
@@ -1,6 +1,20 @@
 package com.mapoker.domain.rules;
 
+/**
+ * プレイヤーが選択した行動を表すレコードです。
+ *
+ * @param type 行動種別
+ * @param amount 行動に伴う金額
+ */
 public record Action(ActionType type, int amount) {
+
+    /**
+     * 行動インスタンスを生成します。
+     *
+     * @param type 行動種別
+     * @param amount 行動に伴う金額
+     * @return 生成した行動
+     */
     public static Action of(ActionType type, int amount) {
         return new Action(type, amount);
     }

--- a/mapoker-backend/src/main/java/com/mapoker/domain/rules/ActionType.java
+++ b/mapoker-backend/src/main/java/com/mapoker/domain/rules/ActionType.java
@@ -3,12 +3,21 @@ package com.mapoker.domain.rules;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+/**
+ * プレイヤー行動の種類を表す列挙型です。
+ */
 public enum ActionType {
+    /** フォールドです。 */
     FOLD("fold"),
+    /** チェックです。 */
     CHECK("check"),
+    /** コールです。 */
     CALL("call"),
+    /** ベットです。 */
     BET("bet"),
+    /** レイズです。 */
     RAISE("raise"),
+    /** オールインです。 */
     ALL_IN("all_in");
 
     private final String label;
@@ -22,6 +31,13 @@ public enum ActionType {
         return label;
     }
 
+    /**
+     * ラベルから行動種別を解決します。
+     *
+     * @param label 行動ラベル
+     * @return 対応する行動種別
+     * @throws IllegalArgumentException 未知のラベルが指定された場合
+     */
     @JsonCreator
     public static ActionType fromLabel(String label) {
         for (ActionType t : values()) {

--- a/mapoker-backend/src/main/java/com/mapoker/domain/rules/ActionValidator.java
+++ b/mapoker-backend/src/main/java/com/mapoker/domain/rules/ActionValidator.java
@@ -1,9 +1,20 @@
 package com.mapoker.domain.rules;
 
+/**
+ * テーブル状態に対してプレイヤー行動の妥当性を検証するユーティリティです。
+ */
 public final class ActionValidator {
 
     private ActionValidator() {}
 
+    /**
+     * 現在状態で指定行動が許可されるかを検証します。
+     *
+     * @param table テーブル状態
+     * @param player プレイヤー状態
+     * @param action 検証対象の行動
+     * @throws IllegalArgumentException 行動が現在状態に適合しない場合
+     */
     public static void validate(TableState table, PlayerState player, Action action) {
         if (player.hasFolded()) throw new IllegalArgumentException("player already folded");
         if (player.isAllIn()) throw new IllegalArgumentException("player is all-in");

--- a/mapoker-backend/src/main/java/com/mapoker/domain/rules/PlayerState.java
+++ b/mapoker-backend/src/main/java/com/mapoker/domain/rules/PlayerState.java
@@ -1,3 +1,11 @@
 package com.mapoker.domain.rules;
 
+/**
+ * 行動検証に必要なプレイヤー状態を表すレコードです。
+ *
+ * @param stack 現在スタック
+ * @param contributed 現ストリートでの拠出額
+ * @param hasFolded フォールド済みかどうか
+ * @param isAllIn オールイン状態かどうか
+ */
 public record PlayerState(int stack, int contributed, boolean hasFolded, boolean isAllIn) {}

--- a/mapoker-backend/src/main/java/com/mapoker/domain/rules/Street.java
+++ b/mapoker-backend/src/main/java/com/mapoker/domain/rules/Street.java
@@ -2,10 +2,17 @@ package com.mapoker.domain.rules;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+/**
+ * ベッティングストリートを表す列挙型です。
+ */
 public enum Street {
+    /** プリフロップです。 */
     PREFLOP("preflop"),
+    /** フロップです。 */
     FLOP("flop"),
+    /** ターンです。 */
     TURN("turn"),
+    /** リバーです。 */
     RIVER("river");
 
     private final String label;
@@ -19,6 +26,11 @@ public enum Street {
         return label;
     }
 
+    /**
+     * 次のストリートを返します。
+     *
+     * @return 次のストリート
+     */
     public Street next() {
         return values()[ordinal() + 1];
     }

--- a/mapoker-backend/src/main/java/com/mapoker/domain/rules/TableState.java
+++ b/mapoker-backend/src/main/java/com/mapoker/domain/rules/TableState.java
@@ -1,3 +1,12 @@
 package com.mapoker.domain.rules;
 
+/**
+ * 行動検証に必要なテーブル状態を表すレコードです。
+ *
+ * @param street 現在のストリート
+ * @param bigBlind ビッグブラインド額
+ * @param currentBet 現在のベット額
+ * @param lastRaiseSize 直近のレイズ幅
+ * @param raiseOpen レイズが再オープンされているかどうか
+ */
 public record TableState(Street street, int bigBlind, int currentBet, int lastRaiseSize, boolean raiseOpen) {}

--- a/mapoker-backend/src/main/java/com/mapoker/infrastructure/config/CorsProperties.java
+++ b/mapoker-backend/src/main/java/com/mapoker/infrastructure/config/CorsProperties.java
@@ -4,6 +4,24 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.util.List;
 
+/**
+ * {@code cors.*} プレフィックスで管理されるCORS設定プロパティ。
+ *
+ * <p>{@code application.properties} に以下のキーで設定する。
+ * 値が未指定またはnullの場合はコンパクトコンストラクタがデフォルト値で補完する。</p>
+ *
+ * <pre>
+ *   cors.allowed-origin-patterns=https://example.com
+ *   cors.allowed-methods=GET,POST
+ *   cors.allowed-headers=*
+ *   cors.allow-credentials=true
+ * </pre>
+ *
+ * @param allowedOriginPatterns 許可するオリジンのパターン。未指定時は {@code ["*"]}
+ * @param allowedMethods        許可するHTTPメソッド。未指定時は {@code ["GET","POST","PUT","DELETE","OPTIONS"]}
+ * @param allowedHeaders        許可するリクエストヘッダ。未指定時は {@code ["*"]}
+ * @param allowCredentials      認証情報（Cookie/Authorization）の送信を許可するか
+ */
 @ConfigurationProperties("cors")
 public record CorsProperties(
         List<String> allowedOriginPatterns,
@@ -11,6 +29,9 @@ public record CorsProperties(
         List<String> allowedHeaders,
         boolean allowCredentials
 ) {
+    /**
+     * コンパクトコンストラクタ。{@code null} または空リストのフィールドにデフォルト値を適用する。
+     */
     public CorsProperties {
         if (allowedOriginPatterns == null || allowedOriginPatterns.isEmpty())
             allowedOriginPatterns = List.of("*");

--- a/mapoker-backend/src/main/java/com/mapoker/infrastructure/config/GameProperties.java
+++ b/mapoker-backend/src/main/java/com/mapoker/infrastructure/config/GameProperties.java
@@ -3,11 +3,28 @@ package com.mapoker.infrastructure.config;
 import com.mapoker.domain.game.OddChipRule;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+/**
+ * {@code game.*} プレフィックスで管理されるゲームデフォルト設定プロパティ。
+ *
+ * <p>ポーカールール固有の定数は {@link com.mapoker.domain.PokerConstants} に定義し、
+ * 環境依存のデフォルト値のみここで管理する。</p>
+ *
+ * <pre>
+ *   game.default-odd-chip-rule=low_index
+ *   game.default-player-name=Player
+ * </pre>
+ *
+ * @param defaultOddChipRule 端数チップの分配ルール。未指定時は {@link OddChipRule#LOW_INDEX}
+ * @param defaultPlayerName  プレイヤー名が未設定の場合に使う表示名。未指定時は {@code "Player"}
+ */
 @ConfigurationProperties("game")
 public record GameProperties(
         OddChipRule defaultOddChipRule,
         String defaultPlayerName
 ) {
+    /**
+     * コンパクトコンストラクタ。{@code null} または空白のフィールドにデフォルト値を適用する。
+     */
     public GameProperties {
         if (defaultOddChipRule == null) defaultOddChipRule = OddChipRule.LOW_INDEX;
         if (defaultPlayerName == null || defaultPlayerName.isBlank()) defaultPlayerName = "Player";

--- a/mapoker-backend/src/main/java/com/mapoker/infrastructure/config/RateLimitConfig.java
+++ b/mapoker-backend/src/main/java/com/mapoker/infrastructure/config/RateLimitConfig.java
@@ -7,10 +7,25 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.Ordered;
 
+/**
+ * ブルートフォース攻撃対策のレートリミットフィルタを登録するBean設定クラス。
+ *
+ * <p>{@code local} プロファイルでは無効化される。本番・ステージング環境でのみ適用され、
+ * 認証エンドポイント ({@code /v1/auth/login}, {@code /v1/auth/register}) への
+ * 過剰リクエストを {@link LoginRateLimitFilter} で遮断する。</p>
+ */
 @Configuration
 @Profile("!local")
 public class RateLimitConfig {
 
+    /**
+     * ログイン・登録エンドポイント向けのレートリミットフィルタを登録する。
+     *
+     * <p>フィルタは {@link Ordered#HIGHEST_PRECEDENCE} + 10 の優先度で適用されるため、
+     * 認証チェックより前にリクエストを遮断できる。</p>
+     *
+     * @return {@link LoginRateLimitFilter} を認証エンドポイントに適用するBean
+     */
     @Bean
     public FilterRegistrationBean<LoginRateLimitFilter> loginRateLimitFilter() {
         FilterRegistrationBean<LoginRateLimitFilter> registration = new FilterRegistrationBean<>();

--- a/mapoker-backend/src/main/java/com/mapoker/infrastructure/config/SecurityConfig.java
+++ b/mapoker-backend/src/main/java/com/mapoker/infrastructure/config/SecurityConfig.java
@@ -18,21 +18,46 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+/**
+ * Spring Security の全体的なセキュリティ設定クラス。
+ *
+ * <p>プロファイルによって動作を切り替える：</p>
+ * <ul>
+ *   <li>{@code local} プロファイル: CSRF無効・全リクエスト許可（開発専用）</li>
+ *   <li>その他: セッション認証・CSRF無効・エンドポイント別アクセス制御</li>
+ * </ul>
+ *
+ * <p>CORS設定は {@link CorsProperties} から取得し、全プロファイルで共有する。</p>
+ */
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
 
     private final CorsProperties corsProperties;
 
+    /**
+     * @param corsProperties {@code cors.*} プロパティから注入されるCORS設定
+     */
     public SecurityConfig(CorsProperties corsProperties) {
         this.corsProperties = corsProperties;
     }
 
+    /**
+     * パスワードのハッシュ化に使用する {@link BCryptPasswordEncoder} を提供する。
+     *
+     * @return BCryptベースのパスワードエンコーダー
+     */
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 
+    /**
+     * {@link UserService} をUserDetailsServiceとして使用する認証プロバイダを構成する。
+     *
+     * @param userService Spring Security の {@code UserDetailsService} として機能するサービス
+     * @return 設定済みの {@link DaoAuthenticationProvider}
+     */
     @Bean
     public DaoAuthenticationProvider authenticationProvider(UserService userService) {
         var provider = new DaoAuthenticationProvider();
@@ -41,11 +66,29 @@ public class SecurityConfig {
         return provider;
     }
 
+    /**
+     * {@link AuthenticationManager} をBeanとして公開する。
+     * コントローラからのプログラム的認証（ログイン処理）で使用する。
+     *
+     * @param config Spring Security の認証設定
+     * @return {@link AuthenticationManager}
+     * @throws Exception 設定取得に失敗した場合
+     */
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
         return config.getAuthenticationManager();
     }
 
+    /**
+     * {@code local} プロファイル専用のセキュリティフィルタチェーン。
+     *
+     * <p>CSRF無効化・全リクエスト許可の設定で、{@code curl} による開発時の動作確認を容易にする。
+     * 本番環境では絶対に使用しないこと。</p>
+     *
+     * @param http HttpSecurity ビルダー
+     * @return 全許可のセキュリティフィルタチェーン
+     * @throws Exception フィルタチェーン構築に失敗した場合
+     */
     @Bean
     @Profile("local")
     public SecurityFilterChain localSecurityFilterChain(HttpSecurity http) throws Exception {
@@ -56,6 +99,16 @@ public class SecurityConfig {
         return http.build();
     }
 
+    /**
+     * 本番・ステージング向けのデフォルトセキュリティフィルタチェーン。
+     *
+     * <p>セッション固定攻撃対策（migrateSession）を有効化し、認証不要なエンドポイントを
+     * {@code /actuator/health} と認証エンドポイントのみに限定する。</p>
+     *
+     * @param http HttpSecurity ビルダー
+     * @return 認証必須のセキュリティフィルタチェーン
+     * @throws Exception フィルタチェーン構築に失敗した場合
+     */
     @Bean
     @Profile("!local")
     public SecurityFilterChain defaultSecurityFilterChain(HttpSecurity http) throws Exception {
@@ -72,6 +125,15 @@ public class SecurityConfig {
         return http.build();
     }
 
+    /**
+     * {@link CorsProperties} の設定値を元に全パス向けのCORS設定ソースを生成する。
+     *
+     * <p>設定値は {@code application.properties} の {@code cors.*} キーから注入される。
+     * ワイルドカードオリジン（{@code "*"}）と {@code allowCredentials=true} は
+     * ブラウザの仕様上組み合わせ不可のため、本番では具体的なオリジンパターンを設定すること。</p>
+     *
+     * @return 全パス ({@code /**}) に適用されるCORS設定ソース
+     */
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();

--- a/mapoker-backend/src/main/java/com/mapoker/infrastructure/config/WalletProperties.java
+++ b/mapoker-backend/src/main/java/com/mapoker/infrastructure/config/WalletProperties.java
@@ -4,6 +4,24 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.util.List;
 
+/**
+ * {@code wallet.*} プレフィックスで管理されるウォレット設定プロパティ。
+ *
+ * <p>チップ付与額・ボーナスクールダウン・バイインレンジなど、
+ * 環境ごとに変更可能なゲーム経済バランスの設定を保持する。
+ * デフォルト値はコンパクトコンストラクタで定義されており、
+ * 設定ファイルで上書きしない限り適用される。</p>
+ *
+ * @param initialGrant             新規登録時に付与するチップ数（デフォルト: 10000）
+ * @param dailyBonusAmount         デイリーボーナスで付与するチップ数（デフォルト: 1000）
+ * @param dailyBonusCooldownHours  デイリーボーナスのクールダウン時間（デフォルト: 24時間）
+ * @param recoveryThreshold        残高がこの値以下になったときリカバリーボーナスを受け取れる閾値（デフォルト: 1000）
+ * @param recoveryAmount           リカバリーボーナスで付与するチップ数（デフォルト: 5000）
+ * @param recoveryCooldownHours    リカバリーボーナスのクールダウン時間（デフォルト: 12時間）
+ * @param minBuyinBbMultiplier     最小バイイン額のBB倍率（デフォルト: 20BB）
+ * @param maxBuyinBbMultiplier     最大バイイン額のBB倍率（デフォルト: 100BB）
+ * @param adminUsernames           管理者権限を持つユーザー名リスト。ブランク・null は除外される
+ */
 @ConfigurationProperties("wallet")
 public record WalletProperties(
         int initialGrant,
@@ -16,6 +34,10 @@ public record WalletProperties(
         int maxBuyinBbMultiplier,
         List<String> adminUsernames
 ) {
+    /**
+     * コンパクトコンストラクタ。0以下の数値フィールドにデフォルト値を適用し、
+     * {@code adminUsernames} からブランク・null エントリを除去してトリムする。
+     */
     public WalletProperties {
         if (initialGrant <= 0) initialGrant = 10000;
         if (dailyBonusAmount <= 0) dailyBonusAmount = 1000;

--- a/mapoker-backend/src/main/java/com/mapoker/infrastructure/persistence/InMemoryGameRepository.java
+++ b/mapoker-backend/src/main/java/com/mapoker/infrastructure/persistence/InMemoryGameRepository.java
@@ -12,6 +12,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+/**
+ * Spring の {@code @Repository} としてローカル実行向けにゲーム状態をメモリ保持する実装です。
+ */
 @Repository
 @Profile("local")
 public class InMemoryGameRepository implements GameRepository {
@@ -19,6 +22,12 @@ public class InMemoryGameRepository implements GameRepository {
     private final Map<String, GameState> games = new LinkedHashMap<>();
     private final Map<String, List<ActionRecord>> actions = new LinkedHashMap<>();
 
+    /**
+     * 新しいゲームを保存します。
+     *
+     * @param id ゲーム ID
+     * @param state 保存するゲーム状態
+     */
     @Override
     public void create(String id, GameState state) {
         state.setId(id);
@@ -26,6 +35,13 @@ public class InMemoryGameRepository implements GameRepository {
         actions.put(id, new ArrayList<>());
     }
 
+    /**
+     * ゲーム状態とアクション履歴を更新します。
+     *
+     * @param id ゲーム ID
+     * @param state 更新後のゲーム状態
+     * @param action 追加するアクション履歴
+     */
     @Override
     public void update(String id, GameState state, ActionRecord action) {
         state.setId(id);
@@ -33,22 +49,45 @@ public class InMemoryGameRepository implements GameRepository {
         actions.computeIfAbsent(id, k -> new ArrayList<>()).add(action);
     }
 
+    /**
+     * ゲーム状態のみを更新します。
+     *
+     * @param id ゲーム ID
+     * @param state 更新後のゲーム状態
+     */
     @Override
     public void update(String id, GameState state) {
         state.setId(id);
         games.put(id, state);
     }
 
+    /**
+     * ID でゲーム状態を取得します。
+     *
+     * @param id ゲーム ID
+     * @return 見つかったゲーム状態
+     */
     @Override
     public Optional<GameState> findById(String id) {
         return Optional.ofNullable(games.get(id));
     }
 
+    /**
+     * 保存済みゲームを全件取得します。
+     *
+     * @return ゲーム状態一覧
+     */
     @Override
     public List<GameState> findAll() {
         return new ArrayList<>(games.values());
     }
 
+    /**
+     * 指定ゲームのアクション履歴を取得します。
+     *
+     * @param gameId ゲーム ID
+     * @return アクション履歴一覧
+     */
     @Override
     public List<ActionRecord> findActionsByGameId(String gameId) {
         return actions.getOrDefault(gameId, List.of());

--- a/mapoker-backend/src/main/java/com/mapoker/infrastructure/persistence/InMemoryHandHistoryRepository.java
+++ b/mapoker-backend/src/main/java/com/mapoker/infrastructure/persistence/InMemoryHandHistoryRepository.java
@@ -12,12 +12,20 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+/**
+ * Spring の {@code @Repository} としてローカル実行向けにハンド履歴をメモリ保持する実装です。
+ */
 @Repository
 @Profile("local")
 public class InMemoryHandHistoryRepository implements HandHistoryRepository {
 
     private final Map<String, List<HandHistoryEntry>> store = new ConcurrentHashMap<>();
 
+    /**
+     * ハンド履歴を保存します。
+     *
+     * @param entry 保存するハンド履歴
+     */
     @Override
     public void save(HandHistoryEntry entry) {
         List<HandHistoryEntry> entries = new ArrayList<>(store.getOrDefault(entry.tableId(), List.of()));
@@ -26,6 +34,13 @@ public class InMemoryHandHistoryRepository implements HandHistoryRepository {
         store.put(entry.tableId(), entries);
     }
 
+    /**
+     * 指定テーブル群の直近ハンド履歴を取得します。
+     *
+     * @param tableIds 対象テーブル ID の一覧
+     * @param limit 取得件数の上限
+     * @return 直近ハンド履歴一覧
+     */
     @Override
     public List<HandHistoryEntry> findRecentByTableIds(List<String> tableIds, int limit) {
         if (tableIds == null || tableIds.isEmpty()) {

--- a/mapoker-backend/src/main/java/com/mapoker/infrastructure/persistence/InMemoryUserRepository.java
+++ b/mapoker-backend/src/main/java/com/mapoker/infrastructure/persistence/InMemoryUserRepository.java
@@ -11,6 +11,9 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
+/**
+ * Spring の {@code @Repository} としてローカル実行向けにユーザー情報をメモリ保持する実装です。
+ */
 @Repository
 @Profile("local")
 public class InMemoryUserRepository implements UserRepository {
@@ -20,6 +23,13 @@ public class InMemoryUserRepository implements UserRepository {
 
     private record UserRow(long id, String username, String passwordHash, LocalDateTime createdAt) {}
 
+    /**
+     * 新しいユーザーを作成します。
+     *
+     * @param username ユーザー名
+     * @param passwordHash ハッシュ化済みパスワード
+     * @return 作成されたユーザー
+     */
     @Override
     public User create(String username, String passwordHash) {
         long id = idSeq.getAndIncrement();
@@ -28,12 +38,24 @@ public class InMemoryUserRepository implements UserRepository {
         return new User(row.id(), row.username(), row.createdAt());
     }
 
+    /**
+     * ユーザー名でユーザーを検索します。
+     *
+     * @param username ユーザー名
+     * @return 見つかったユーザー
+     */
     @Override
     public Optional<User> findByUsername(String username) {
         return Optional.ofNullable(store.get(username))
                 .map(r -> new User(r.id(), r.username(), r.createdAt()));
     }
 
+    /**
+     * ユーザー名でパスワードハッシュを取得します。
+     *
+     * @param username ユーザー名
+     * @return パスワードハッシュ
+     */
     @Override
     public Optional<String> findPasswordHashByUsername(String username) {
         return Optional.ofNullable(store.get(username)).map(UserRow::passwordHash);

--- a/mapoker-backend/src/main/java/com/mapoker/infrastructure/persistence/InMemoryUserTableHistoryRepository.java
+++ b/mapoker-backend/src/main/java/com/mapoker/infrastructure/persistence/InMemoryUserTableHistoryRepository.java
@@ -13,12 +13,22 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+/**
+ * Spring の {@code @Repository} としてローカル実行向けに参加履歴をメモリ保持する実装です。
+ */
 @Repository
 @Profile("local")
 public class InMemoryUserTableHistoryRepository implements UserTableHistoryRepository {
 
     private final Map<String, List<UserTableHistoryEntry>> store = new ConcurrentHashMap<>();
 
+    /**
+     * テーブル参加を履歴へ記録します。
+     *
+     * @param username ユーザー名
+     * @param table 参加テーブル
+     * @param seatIndex 着席位置
+     */
     @Override
     public void recordJoin(String username, TableRecord table, int seatIndex) {
         List<UserTableHistoryEntry> entries = new ArrayList<>(store.getOrDefault(username, List.of()));
@@ -44,6 +54,13 @@ public class InMemoryUserTableHistoryRepository implements UserTableHistoryRepos
         store.put(username, entries);
     }
 
+    /**
+     * テーブル退出を履歴へ記録します。
+     *
+     * @param username ユーザー名
+     * @param tableId テーブル ID
+     * @param seatIndex 着席位置
+     */
     @Override
     public void recordLeave(String username, String tableId, Integer seatIndex) {
         List<UserTableHistoryEntry> entries = new ArrayList<>(store.getOrDefault(username, List.of()));
@@ -67,6 +84,13 @@ public class InMemoryUserTableHistoryRepository implements UserTableHistoryRepos
         store.put(username, entries);
     }
 
+    /**
+     * ユーザーの直近参加履歴を取得します。
+     *
+     * @param username ユーザー名
+     * @param limit 取得件数の上限
+     * @return 参加履歴一覧
+     */
     @Override
     public List<UserTableHistoryEntry> findRecentByUsername(String username, int limit) {
         return store.getOrDefault(username, List.of()).stream()

--- a/mapoker-backend/src/main/java/com/mapoker/infrastructure/persistence/PostgresGameRepository.java
+++ b/mapoker-backend/src/main/java/com/mapoker/infrastructure/persistence/PostgresGameRepository.java
@@ -24,6 +24,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+/**
+ * Spring の {@code @Repository} として PostgreSQL へゲーム状態を永続化する実装です。
+ */
 @Repository
 @Profile("postgresql")
 public class PostgresGameRepository implements GameRepository {
@@ -38,6 +41,12 @@ public class PostgresGameRepository implements GameRepository {
         this.mapper = mapper;
     }
 
+    /**
+     * 新しいゲームを永続化します。
+     *
+     * @param id ゲーム ID
+     * @param state 保存するゲーム状態
+     */
     @Override
     @Transactional
     public void create(String id, GameState state) {
@@ -46,6 +55,13 @@ public class PostgresGameRepository implements GameRepository {
         insertPlayers(id, state);
     }
 
+    /**
+     * ゲーム状態とアクション履歴を更新します。
+     *
+     * @param id ゲーム ID
+     * @param state 更新後のゲーム状態
+     * @param action 追加するアクション履歴
+     */
     @Override
     @Transactional
     public void update(String id, GameState state, ActionRecord action) {
@@ -55,6 +71,12 @@ public class PostgresGameRepository implements GameRepository {
         insertAction(id, action);
     }
 
+    /**
+     * ゲーム状態のみを更新します。
+     *
+     * @param id ゲーム ID
+     * @param state 更新後のゲーム状態
+     */
     @Override
     @Transactional
     public void update(String id, GameState state) {
@@ -63,6 +85,12 @@ public class PostgresGameRepository implements GameRepository {
         updatePlayers(id, state);
     }
 
+    /**
+     * ID でゲーム状態を取得します。
+     *
+     * @param id ゲーム ID
+     * @return 見つかったゲーム状態
+     */
     @Override
     public Optional<GameState> findById(String id) {
         List<Map<String, Object>> rows = jdbc.queryForList(
@@ -73,6 +101,11 @@ public class PostgresGameRepository implements GameRepository {
         return Optional.of(toGameState(rows.get(0), playerRows));
     }
 
+    /**
+     * すべてのゲーム状態を取得します。
+     *
+     * @return ゲーム状態一覧
+     */
     @Override
     public List<GameState> findAll() {
         List<Map<String, Object>> gameRows = jdbc.queryForList(
@@ -96,6 +129,12 @@ public class PostgresGameRepository implements GameRepository {
         return result;
     }
 
+    /**
+     * 指定ゲームのアクション履歴を取得します。
+     *
+     * @param gameId ゲーム ID
+     * @return アクション履歴一覧
+     */
     @Override
     public List<ActionRecord> findActionsByGameId(String gameId) {
         return jdbc.query(

--- a/mapoker-backend/src/main/java/com/mapoker/infrastructure/persistence/PostgresHandHistoryRepository.java
+++ b/mapoker-backend/src/main/java/com/mapoker/infrastructure/persistence/PostgresHandHistoryRepository.java
@@ -16,6 +16,9 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 
+/**
+ * Spring の {@code @Repository} として PostgreSQL へハンド履歴を保存する実装です。
+ */
 @Repository
 @Profile("postgresql")
 public class PostgresHandHistoryRepository implements HandHistoryRepository {
@@ -31,6 +34,11 @@ public class PostgresHandHistoryRepository implements HandHistoryRepository {
         this.mapper = mapper;
     }
 
+    /**
+     * ハンド履歴を保存します。
+     *
+     * @param entry 保存するハンド履歴
+     */
     @Override
     public void save(HandHistoryEntry entry) {
         jdbc.update("""
@@ -46,6 +54,13 @@ public class PostgresHandHistoryRepository implements HandHistoryRepository {
                 Timestamp.from(entry.finishedAt()));
     }
 
+    /**
+     * 指定テーブル群の直近ハンド履歴を取得します。
+     *
+     * @param tableIds 対象テーブル ID の一覧
+     * @param limit 取得件数の上限
+     * @return 直近ハンド履歴一覧
+     */
     @Override
     public List<HandHistoryEntry> findRecentByTableIds(List<String> tableIds, int limit) {
         if (tableIds == null || tableIds.isEmpty()) {

--- a/mapoker-backend/src/main/java/com/mapoker/infrastructure/persistence/PostgresUserRepository.java
+++ b/mapoker-backend/src/main/java/com/mapoker/infrastructure/persistence/PostgresUserRepository.java
@@ -10,6 +10,9 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Optional;
 
+/**
+ * Spring の {@code @Repository} として PostgreSQL へユーザー情報を保存する実装です。
+ */
 @Repository
 @Profile("postgresql")
 public class PostgresUserRepository implements UserRepository {
@@ -20,6 +23,13 @@ public class PostgresUserRepository implements UserRepository {
         this.jdbc = jdbc;
     }
 
+    /**
+     * 新しいユーザーを作成します。
+     *
+     * @param username ユーザー名
+     * @param passwordHash ハッシュ化済みパスワード
+     * @return 作成されたユーザー
+     */
     @Override
     public User create(String username, String passwordHash) {
         return jdbc.queryForObject(
@@ -28,6 +38,12 @@ public class PostgresUserRepository implements UserRepository {
                 username, passwordHash);
     }
 
+    /**
+     * ユーザー名でユーザーを検索します。
+     *
+     * @param username ユーザー名
+     * @return 見つかったユーザー
+     */
     @Override
     public Optional<User> findByUsername(String username) {
         var results = jdbc.query(
@@ -37,6 +53,12 @@ public class PostgresUserRepository implements UserRepository {
         return results.isEmpty() ? Optional.empty() : Optional.of(results.get(0));
     }
 
+    /**
+     * ユーザー名でパスワードハッシュを取得します。
+     *
+     * @param username ユーザー名
+     * @return パスワードハッシュ
+     */
     @Override
     public Optional<String> findPasswordHashByUsername(String username) {
         var results = jdbc.query(

--- a/mapoker-backend/src/main/java/com/mapoker/infrastructure/persistence/PostgresUserTableHistoryRepository.java
+++ b/mapoker-backend/src/main/java/com/mapoker/infrastructure/persistence/PostgresUserTableHistoryRepository.java
@@ -16,6 +16,9 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.List;
 
+/**
+ * Spring の {@code @Repository} として PostgreSQL へ参加履歴を保存する実装です。
+ */
 @Repository
 @Profile("postgresql")
 public class PostgresUserTableHistoryRepository implements UserTableHistoryRepository {
@@ -30,6 +33,13 @@ public class PostgresUserTableHistoryRepository implements UserTableHistoryRepos
         this.mapper = mapper;
     }
 
+    /**
+     * テーブル参加を履歴へ記録します。
+     *
+     * @param username ユーザー名
+     * @param table 参加テーブル
+     * @param seatIndex 着席位置
+     */
     @Override
     public void recordJoin(String username, TableRecord table, int seatIndex) {
         int updated = jdbc.update("""
@@ -60,6 +70,13 @@ public class PostgresUserTableHistoryRepository implements UserTableHistoryRepos
                 toJson(table.flags()));
     }
 
+    /**
+     * テーブル退出を履歴へ記録します。
+     *
+     * @param username ユーザー名
+     * @param tableId テーブル ID
+     * @param seatIndex 着席位置
+     */
     @Override
     public void recordLeave(String username, String tableId, Integer seatIndex) {
         String sql = seatIndex != null
@@ -94,6 +111,13 @@ public class PostgresUserTableHistoryRepository implements UserTableHistoryRepos
         jdbc.update(sql, username, tableId);
     }
 
+    /**
+     * ユーザーの直近参加履歴を取得します。
+     *
+     * @param username ユーザー名
+     * @param limit 取得件数の上限
+     * @return 参加履歴一覧
+     */
     @Override
     public List<UserTableHistoryEntry> findRecentByUsername(String username, int limit) {
         return jdbc.query("""

--- a/mapoker-backend/src/main/java/com/mapoker/infrastructure/persistence/PostgresWalletRepository.java
+++ b/mapoker-backend/src/main/java/com/mapoker/infrastructure/persistence/PostgresWalletRepository.java
@@ -17,6 +17,9 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * Spring の {@code @Repository} として PostgreSQL へウォレット残高と台帳を保存する実装です。
+ */
 @Repository
 @Profile("postgresql")
 public class PostgresWalletRepository implements WalletRepository {
@@ -29,6 +32,11 @@ public class PostgresWalletRepository implements WalletRepository {
         this.walletProperties = walletProperties;
     }
 
+    /**
+     * ユーザーウォレットを初期化します。
+     *
+     * @param username ユーザー名
+     */
     @Override
     @Transactional
     public void initializeWallet(String username) {
@@ -65,6 +73,12 @@ public class PostgresWalletRepository implements WalletRepository {
                 idempotencyKey);
     }
 
+    /**
+     * ユーザー名からウォレット残高を取得します。
+     *
+     * @param username ユーザー名
+     * @return ウォレット情報
+     */
     @Override
     public Optional<WalletEntry> findByUsername(String username) {
         List<WalletEntry> results = jdbc.query("""
@@ -78,6 +92,17 @@ public class PostgresWalletRepository implements WalletRepository {
         return results.isEmpty() ? Optional.empty() : Optional.of(results.get(0));
     }
 
+    /**
+     * 指定額を出金します。
+     *
+     * @param username ユーザー名
+     * @param amount 出金額
+     * @param reason 取引理由
+     * @param refType 参照種別
+     * @param refId 参照 ID
+     * @param idempotencyKey 冪等性キー
+     * @return 出金できた場合は {@code true}
+     */
     @Override
     @Transactional
     public boolean debit(String username, long amount, String reason, String refType, String refId, String idempotencyKey) {
@@ -130,6 +155,17 @@ public class PostgresWalletRepository implements WalletRepository {
         }
     }
 
+    /**
+     * 指定額を入金します。
+     *
+     * @param username ユーザー名
+     * @param amount 入金額
+     * @param reason 取引理由
+     * @param refType 参照種別
+     * @param refId 参照 ID
+     * @param idempotencyKey 冪等性キー
+     * @throws IllegalStateException ウォレットが存在しない場合
+     */
     @Override
     @Transactional
     public void credit(String username, long amount, String reason, String refType, String refId, String idempotencyKey) {
@@ -178,6 +214,13 @@ public class PostgresWalletRepository implements WalletRepository {
         }
     }
 
+    /**
+     * 直近の台帳履歴を取得します。
+     *
+     * @param username ユーザー名
+     * @param limit 取得件数の上限
+     * @return 台帳履歴一覧
+     */
     @Override
     public List<WalletLedgerEntry> findLedger(String username, int limit) {
         return jdbc.query("""
@@ -193,6 +236,13 @@ public class PostgresWalletRepository implements WalletRepository {
                 Math.max(1, limit));
     }
 
+    /**
+     * 指定理由の最終台帳時刻を取得します。
+     *
+     * @param username ユーザー名
+     * @param reason 取引理由
+     * @return 最終台帳時刻
+     */
     @Override
     public Optional<Instant> findLastLedgerTime(String username, String reason) {
         List<Instant> results = jdbc.query("""

--- a/mapoker-backend/src/main/java/com/mapoker/interfaces/http/AuthController.java
+++ b/mapoker-backend/src/main/java/com/mapoker/interfaces/http/AuthController.java
@@ -28,6 +28,18 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 認証関連エンドポイントを提供するコントローラー。
+ *
+ * <p>ユーザー登録・ログイン・ログアウトおよび認証済みユーザー情報の取得を担当する。
+ * セッションは {@link HttpSession} で管理され、Spring Security の
+ * {@link org.springframework.security.web.context.HttpSessionSecurityContextRepository}
+ * を経由して永続化される。
+ *
+ * <p>ローカル開発プロファイル ({@code SPRING_PROFILES_ACTIVE=local}) では認証が無効化されるため、
+ * {@code principal} が {@code null} になる場合がある。各エンドポイントで {@code null} チェックを
+ * 行っているのはそのためである。
+ */
 @RestController
 @RequestMapping("/v1/auth")
 public class AuthController {
@@ -47,6 +59,15 @@ public class AuthController {
         this.authenticationManager = authenticationManager;
     }
 
+    /**
+     * 新規ユーザーを登録し、そのままセッションを確立して返す。
+     *
+     * <p>登録と同時にログイン状態になるため、クライアントは別途ログインリクエストを送る必要がない。
+     *
+     * @param req     ユーザー名とパスワードを含む登録リクエスト
+     * @param request セッション生成に使用するHTTPリクエスト
+     * @return 登録されたユーザーの {@link UserResponse}（HTTP 201）
+     */
     @PostMapping("/register")
     @ResponseStatus(HttpStatus.CREATED)
     public UserResponse register(@Valid @RequestBody RegisterRequest req, HttpServletRequest request) {
@@ -54,11 +75,30 @@ public class AuthController {
         return createSessionAndReturn(req.username(), req.password(), request);
     }
 
+    /**
+     * 既存ユーザーを認証してセッションを確立する。
+     *
+     * @param req     ユーザー名とパスワードを含むログインリクエスト
+     * @param request セッション生成に使用するHTTPリクエスト
+     * @return 認証されたユーザーの {@link UserResponse}（HTTP 200）
+     */
     @PostMapping("/login")
     public UserResponse login(@Valid @RequestBody LoginRequest req, HttpServletRequest request) {
         return createSessionAndReturn(req.username(), req.password(), request);
     }
 
+    /**
+     * 認証を実行してセッションを確立し、ユーザー情報を返す内部ヘルパー。
+     *
+     * <p>{@link SecurityContextHolder} に認証情報をセットした後、
+     * セッションに {@code SPRING_SECURITY_CONTEXT_KEY} として格納することで
+     * 後続リクエストでも認証状態が維持される。
+     *
+     * @param username   ユーザー名
+     * @param rawPassword 平文パスワード
+     * @param request    セッション生成に使用するHTTPリクエスト
+     * @return ユーザーの {@link UserResponse}
+     */
     private UserResponse createSessionAndReturn(String username, String rawPassword, HttpServletRequest request) {
         Authentication auth = authenticationManager.authenticate(
                 new UsernamePasswordAuthenticationToken(username, rawPassword));
@@ -71,6 +111,15 @@ public class AuthController {
         return new UserResponse(user.id(), user.username());
     }
 
+    /**
+     * 現在ログイン中のユーザー情報を返す。
+     *
+     * <p>未認証の場合は HTTP 401 を返す。ローカルプロファイルでは {@code principal} が
+     * {@code null} になり得るため、その場合も 401 を返す。
+     *
+     * @param principal Spring Security が注入する認証済みユーザー詳細。未認証時は {@code null}
+     * @return 認証済みユーザーの {@link UserResponse}、または HTTP 401
+     */
     @GetMapping("/me")
     public ResponseEntity<UserResponse> me(@AuthenticationPrincipal UserDetails principal) {
         if (principal == null) {
@@ -80,6 +129,12 @@ public class AuthController {
         return ResponseEntity.ok(new UserResponse(user.id(), user.username()));
     }
 
+    /**
+     * 認証済みユーザーの直近テーブル参加履歴を返す。
+     *
+     * @param principal Spring Security が注入する認証済みユーザー詳細。未認証時は {@code null}
+     * @return {@link UserTableHistoryResponse} のリスト、または HTTP 401
+     */
     @GetMapping("/history")
     public ResponseEntity<java.util.List<UserTableHistoryResponse>> history(@AuthenticationPrincipal UserDetails principal) {
         if (principal == null) {
@@ -90,6 +145,13 @@ public class AuthController {
                 .toList());
     }
 
+    /**
+     * 認証済みユーザーの直近ハンド履歴を返す。
+     *
+     * @param principal Spring Security が注入する認証済みユーザー詳細。未認証時は {@code null}
+     * @param limit     取得件数の上限（デフォルト 20）
+     * @return {@link HandHistoryResponse} のリスト、または HTTP 401
+     */
     @GetMapping("/hand-history")
     public ResponseEntity<java.util.List<HandHistoryResponse>> handHistory(
             @AuthenticationPrincipal UserDetails principal,
@@ -102,6 +164,15 @@ public class AuthController {
                 .toList());
     }
 
+    /**
+     * 現在のセッションを無効化してログアウトする。
+     *
+     * <p>セッションが存在しない場合は何もせず正常終了する。
+     * {@link SecurityContextHolder} もクリアすることで、同一スレッド内での
+     * 認証情報の残存を防ぐ。
+     *
+     * @param request セッション取得に使用するHTTPリクエスト
+     */
     @PostMapping("/logout")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void logout(HttpServletRequest request) {

--- a/mapoker-backend/src/main/java/com/mapoker/interfaces/http/GameController.java
+++ b/mapoker-backend/src/main/java/com/mapoker/interfaces/http/GameController.java
@@ -14,6 +14,17 @@ import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.List;
 
+/**
+ * ゲーム操作エンドポイントを提供するコントローラー。
+ *
+ * <p>Texas Hold'em ポーカーゲームのライフサイクル（作成・アクション適用・ショーダウン）を
+ * REST API として公開する。状態はすべてサーバーサイドで管理され、クライアントはゲームIDを
+ * 介してステートレスにアクセスする。
+ *
+ * <p>ホールカードの可視性はバックエンドで制御される。{@code viewer_index} クエリパラメータで
+ * 指定されたプレイヤーのカードのみ返し、ショーダウン・終了時は全員のカードを公開する。
+ * 認証済みユーザーの場合、テーブルシートインデックスを自動解決して適切なカードを返す。
+ */
 @RestController
 @RequestMapping("/v1/games")
 public class GameController {
@@ -28,6 +39,15 @@ public class GameController {
         this.tableService = tableService;
     }
 
+    /**
+     * 新しいゲームを作成する。
+     *
+     * <p>{@code odd_chip_rule} が省略された場合は {@link GameProperties#defaultOddChipRule()} が適用される。
+     * {@code seed} を指定するとデッキシャッフルの再現性が保証され、テストに利用できる。
+     *
+     * @param req プレイヤー情報・ボタン位置・ブラインド額・オプションのシードを含むリクエスト
+     * @return 作成されたゲームの {@link GameResponse}（HTTP 201）
+     */
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public GameResponse createGame(@Valid @RequestBody CreateGameRequest req) {
@@ -39,6 +59,13 @@ public class GameController {
         return GameResponse.from(state, null, false);
     }
 
+    /**
+     * 全ゲームの一覧を返す。
+     *
+     * <p>ホールカードは一切含まれない（{@code viewerIndex=null, spectator=false}）。
+     *
+     * @return 全ゲームの {@link GameResponse} リスト
+     */
     @GetMapping
     public List<GameResponse> listGames() {
         return gameService.listGames().stream()
@@ -46,6 +73,19 @@ public class GameController {
                 .toList();
     }
 
+    /**
+     * 指定IDのゲーム状態を返す。
+     *
+     * <p>認証済みユーザーの場合、テーブルメンバーシップからシートインデックスを自動解決し、
+     * 自分のホールカードのみを含めて返す。{@code spectator=1} を指定するとホールカードを
+     * 一切含まない観戦モードになる。
+     *
+     * @param id          ゲームID
+     * @param viewerIndex 表示するプレイヤーのインデックス（認証済み時は自動解決されるため通常不要）
+     * @param spectator   {@code "1"} または {@code "true"} を指定するとホールカードを非表示にする
+     * @param principal   Spring Security が注入する認証済みユーザー詳細。未認証時は {@code null}
+     * @return ゲームの {@link GameResponse}
+     */
     @GetMapping("/{id}")
     public GameResponse getGame(
             @PathVariable String id,
@@ -57,11 +97,33 @@ public class GameController {
         return GameResponse.from(gameService.getGame(id), effectiveViewerIndex, isSpectator);
     }
 
+    /**
+     * 新しいハンドを開始する。
+     *
+     * <p>ゲームの状態が {@code finished} であることが前提。ブラインド額はハンドごとに変更可能。
+     *
+     * @param id  ゲームID
+     * @param req 新しいビッグブラインド額を含むリクエスト
+     * @return ハンド開始後のゲームの {@link GameResponse}
+     */
     @PostMapping("/{id}/start")
     public GameResponse startHand(@PathVariable String id, @Valid @RequestBody StartHandRequest req) {
         return GameResponse.from(tableService.startHand(id, req.bigBlind()), null, false);
     }
 
+    /**
+     * プレイヤーのアクションを適用する。
+     *
+     * <p>{@code bet}/{@code raise} の {@code amount} は増分ではなく合計額（raise-to total）を指定する。
+     * {@code call} は {@code amount=0} で自動コールとなる。
+     * ミニマムレイズはドメイン層で検証され、違反時は {@link IllegalArgumentException} がスローされる。
+     *
+     * @param id          ゲームID
+     * @param req         プレイヤーインデックスとアクション内容を含むリクエスト
+     * @param viewerIndex 表示するプレイヤーのインデックス（認証済み時は自動解決）
+     * @param principal   Spring Security が注入する認証済みユーザー詳細。未認証時は {@code null}
+     * @return アクション適用後のゲームの {@link GameResponse}
+     */
     @PostMapping("/{id}/actions")
     public GameResponse applyAction(
             @PathVariable String id,
@@ -74,11 +136,26 @@ public class GameController {
         return GameResponse.from(state, effectiveViewerIndex, false);
     }
 
+    /**
+     * 指定ゲームのアクション履歴を返す。
+     *
+     * @param id ゲームID
+     * @return アクション履歴の {@link ActionsResponse}
+     */
     @GetMapping("/{id}/actions")
     public ActionsResponse getActions(@PathVariable String id) {
         return ActionsResponse.from(gameService.getActions(id));
     }
 
+    /**
+     * ショーダウンを解決してポットを分配する。
+     *
+     * <p>ショーダウン後は全プレイヤーのホールカードが公開される（{@code viewerIndex=null}）。
+     * レスポンスには {@code last_showdown} フィールドに勝者・最強ハンド・支払い額が含まれる。
+     *
+     * @param id ゲームID
+     * @return ショーダウン解決後のゲームの {@link GameResponse}
+     */
     @PostMapping("/{id}/showdown")
     public GameResponse resolveShowdown(@PathVariable String id) {
         gameService.resolveShowdown(id);
@@ -87,6 +164,17 @@ public class GameController {
         return GameResponse.from(state, null, false);
     }
 
+    /**
+     * 有効な {@code viewerIndex} を解決する内部ヘルパー。
+     *
+     * <p>認証済みユーザーの場合はテーブルメンバーシップからシートインデックスを取得し、
+     * リクエストパラメータを上書きする。未認証時はリクエストパラメータの値をそのまま返す。
+     *
+     * @param id                    ゲームID
+     * @param requestedViewerIndex  クライアントが指定した {@code viewer_index}
+     * @param principal             認証済みユーザー詳細。未認証時は {@code null}
+     * @return 有効な {@code viewerIndex}、または {@code null}（観戦モード相当）
+     */
     private Integer resolveViewerIndex(String id, Integer requestedViewerIndex, UserDetails principal) {
         if (principal == null) {
             return requestedViewerIndex;

--- a/mapoker-backend/src/main/java/com/mapoker/interfaces/http/GlobalExceptionHandler.java
+++ b/mapoker-backend/src/main/java/com/mapoker/interfaces/http/GlobalExceptionHandler.java
@@ -14,33 +14,66 @@ import jakarta.validation.ConstraintViolationException;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
+/**
+ * Spring の {@code @RestControllerAdvice} として HTTP 例外を API エラー応答へ変換するハンドラです。
+ */
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    /**
+     * 未検出エラーを 404 応答へ変換します。
+     *
+     * @param e 発生した例外
+     * @return エラー応答
+     */
     @ExceptionHandler(NoSuchElementException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public ErrorResponse handleNotFound(NoSuchElementException e) {
         return ErrorResponse.of("not_found", e.getMessage());
     }
 
+    /**
+     * 不正な入力エラーを 400 応答へ変換します。
+     *
+     * @param e 発生した例外
+     * @return エラー応答
+     */
     @ExceptionHandler(IllegalArgumentException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ErrorResponse handleBadRequest(IllegalArgumentException e) {
         return ErrorResponse.of("invalid_request", e.getMessage());
     }
 
+    /**
+     * 状態不整合エラーを 400 応答へ変換します。
+     *
+     * @param e 発生した例外
+     * @return エラー応答
+     */
     @ExceptionHandler(IllegalStateException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ErrorResponse handleInvalidState(IllegalStateException e) {
         return ErrorResponse.of("invalid_action", e.getMessage());
     }
 
+    /**
+     * 権限不足エラーを 403 応答へ変換します。
+     *
+     * @param e 発生した例外
+     * @return エラー応答
+     */
     @ExceptionHandler(AccessDeniedException.class)
     @ResponseStatus(HttpStatus.FORBIDDEN)
     public ErrorResponse handleAccessDenied(AccessDeniedException e) {
         return ErrorResponse.of("forbidden", e.getMessage());
     }
 
+    /**
+     * Bean Validation の入力検証エラーを 400 応答へ変換します。
+     *
+     * @param e 発生した例外
+     * @return エラー応答
+     */
     @ExceptionHandler(MethodArgumentNotValidException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ErrorResponse handleValidation(MethodArgumentNotValidException e) {
@@ -53,18 +86,36 @@ public class GlobalExceptionHandler {
         return ErrorResponse.of("invalid_request", message);
     }
 
+    /**
+     * パラメータ制約違反を 400 応答へ変換します。
+     *
+     * @param e 発生した例外
+     * @return エラー応答
+     */
     @ExceptionHandler(ConstraintViolationException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ErrorResponse handleConstraintViolation(ConstraintViolationException e) {
         return ErrorResponse.of("invalid_request", e.getMessage());
     }
 
+    /**
+     * 読み取り不能なリクエスト本文を 400 応答へ変換します。
+     *
+     * @param e 発生した例外
+     * @return エラー応答
+     */
     @ExceptionHandler(HttpMessageNotReadableException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ErrorResponse handleUnreadableMessage(HttpMessageNotReadableException e) {
         return ErrorResponse.of("invalid_request", "malformed request body");
     }
 
+    /**
+     * 想定外例外を 500 応答へ変換します。
+     *
+     * @param e 発生した例外
+     * @return エラー応答
+     */
     @ExceptionHandler(Exception.class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     public ErrorResponse handleGeneral(Exception e) {

--- a/mapoker-backend/src/main/java/com/mapoker/interfaces/http/RoomController.java
+++ b/mapoker-backend/src/main/java/com/mapoker/interfaces/http/RoomController.java
@@ -11,6 +11,9 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+/**
+ * Spring の {@code @RestController} としてルーム参加者 API を提供するコントローラです。
+ */
 @RestController
 @RequestMapping("/v1/rooms")
 public class RoomController {
@@ -21,6 +24,13 @@ public class RoomController {
         this.tableService = tableService;
     }
 
+    /**
+     * 参加者表示用 DTO です。
+     *
+     * @param name 参加者名
+     * @param seatIndex 着席位置
+     * @param joinedAt 参加日時
+     */
     public record MemberRecord(
             String name,
             @JsonProperty("seat_index") int seatIndex,
@@ -29,11 +39,25 @@ public class RoomController {
 
     private record MembersResponse(List<MemberRecord> members) {}
 
+    /**
+     * ルーム参加者一覧を取得します。
+     *
+     * @param id ルーム ID
+     * @return 参加者一覧
+     */
     @GetMapping("/{id}/members")
     public MembersResponse getMembers(@PathVariable String id) {
         return new MembersResponse(mapMembers(tableService.getMembers(id)));
     }
 
+    /**
+     * 認証ユーザーまたは指定名義でルームへ参加します。
+     *
+     * @param id ルーム ID
+     * @param body 参加リクエスト
+     * @param principal 認証済みユーザー
+     * @return 更新後の参加者一覧
+     */
     @PostMapping("/{id}/join")
     public MembersResponse join(@PathVariable String id,
                                 @Valid @RequestBody(required = false) TableMembershipRequest body,
@@ -43,6 +67,14 @@ public class RoomController {
         return new MembersResponse(mapMembers(tableService.join(id, name, buyIn).members()));
     }
 
+    /**
+     * 認証ユーザーまたは指定名義でルームから退出します。
+     *
+     * @param id ルーム ID
+     * @param body 退出リクエスト
+     * @param principal 認証済みユーザー
+     * @return 更新後の参加者一覧
+     */
     @PostMapping("/{id}/leave")
     public MembersResponse leave(@PathVariable String id,
                                  @Valid @RequestBody(required = false) TableMembershipRequest body,

--- a/mapoker-backend/src/main/java/com/mapoker/interfaces/http/TableController.java
+++ b/mapoker-backend/src/main/java/com/mapoker/interfaces/http/TableController.java
@@ -16,6 +16,9 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+/**
+ * Spring の {@code @RestController} としてテーブル管理 API を提供するコントローラです。
+ */
 @RestController
 @RequestMapping("/v1/tables")
 public class TableController {
@@ -26,6 +29,12 @@ public class TableController {
         this.tableService = tableService;
     }
 
+    /**
+     * 新しいテーブルを作成します。
+     *
+     * @param request テーブル作成条件
+     * @return 作成結果
+     */
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public TableResponse createTable(@Valid @RequestBody CreateTableRequest request) {
@@ -40,6 +49,13 @@ public class TableController {
         return TableResponse.from(result.table(), tableService.getMembers(result.table().id()), GameResponse.from(result.game(), null, false));
     }
 
+    /**
+     * 条件に一致するテーブル一覧を取得します。
+     *
+     * @param visibility 公開設定の絞り込み条件
+     * @param flags 必須フラグの絞り込み条件
+     * @return テーブル一覧
+     */
     @GetMapping
     public List<TableResponse> listTables(@RequestParam(required = false) String visibility,
                                           @RequestParam(required = false) String flags) {
@@ -48,17 +64,37 @@ public class TableController {
                 .toList();
     }
 
+    /**
+     * 指定テーブルの詳細を取得します。
+     *
+     * @param id テーブル ID
+     * @return テーブル詳細
+     */
     @GetMapping("/{id}")
     public TableResponse getTable(@PathVariable String id) {
         TableRecord table = tableService.getTable(id);
         return TableResponse.from(table, tableService.getMembers(id), GameResponse.from(tableService.getTableGame(id), null, false));
     }
 
+    /**
+     * 指定テーブルの参加者一覧を取得します。
+     *
+     * @param id テーブル ID
+     * @return 参加者一覧
+     */
     @GetMapping("/{id}/members")
     public MembersResponse getMembers(@PathVariable String id) {
         return new MembersResponse(toMembers(tableService.getMembers(id)));
     }
 
+    /**
+     * 認証ユーザーまたは指定名義でテーブルへ参加します。
+     *
+     * @param id テーブル ID
+     * @param body 参加リクエスト
+     * @param principal 認証済みユーザー
+     * @return 割り当て席と参加者一覧
+     */
     @PostMapping("/{id}/join")
     public JoinResponse join(@PathVariable String id,
                              @Valid @RequestBody(required = false) TableMembershipRequest body,
@@ -69,6 +105,14 @@ public class TableController {
         return new JoinResponse(result.assignedSeatIndex(), toMembers(result.members()));
     }
 
+    /**
+     * 認証ユーザーまたは指定名義でテーブルから退出します。
+     *
+     * @param id テーブル ID
+     * @param body 退出リクエスト
+     * @param principal 認証済みユーザー
+     * @return 更新後の参加者一覧
+     */
     @PostMapping("/{id}/leave")
     public MembersResponse leave(@PathVariable String id,
                                  @Valid @RequestBody(required = false) TableMembershipRequest body,
@@ -83,8 +127,19 @@ public class TableController {
                 .toList();
     }
 
+    /**
+     * 参加者一覧レスポンスです。
+     *
+     * @param members 参加者一覧
+     */
     public record MembersResponse(List<TableResponse.MemberDto> members) {}
 
+    /**
+     * 参加結果レスポンスです。
+     *
+     * @param assignedSeatIndex 割り当て席番号
+     * @param members 更新後の参加者一覧
+     */
     public record JoinResponse(
             @JsonProperty("assigned_seat_index") int assignedSeatIndex,
             List<TableResponse.MemberDto> members

--- a/mapoker-backend/src/main/java/com/mapoker/interfaces/http/WalletController.java
+++ b/mapoker-backend/src/main/java/com/mapoker/interfaces/http/WalletController.java
@@ -20,6 +20,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+/**
+ * Spring の {@code @RestController} としてウォレット参照とボーナス請求 API を提供するコントローラです。
+ */
 @RestController
 @Profile("postgresql")
 @RequestMapping("/v1/wallet")
@@ -33,6 +36,12 @@ public class WalletController {
         this.walletService = walletService;
     }
 
+    /**
+     * 認証ユーザーのウォレット情報を取得します。
+     *
+     * @param principal 認証済みユーザー
+     * @return ウォレット応答
+     */
     @GetMapping
     public ResponseEntity<WalletResponse> getWallet(@AuthenticationPrincipal UserDetails principal) {
         if (principal == null) {
@@ -41,6 +50,13 @@ public class WalletController {
         return ResponseEntity.ok(loadWalletResponse(principal.getUsername()));
     }
 
+    /**
+     * 認証ユーザーの台帳履歴を取得します。
+     *
+     * @param principal 認証済みユーザー
+     * @param limit 取得件数
+     * @return 台帳履歴応答
+     */
     @GetMapping("/ledger")
     public ResponseEntity<List<WalletLedgerResponse>> getLedger(
             @AuthenticationPrincipal UserDetails principal,
@@ -54,6 +70,12 @@ public class WalletController {
                 .toList());
     }
 
+    /**
+     * 日次ボーナスを請求します。
+     *
+     * @param principal 認証済みユーザー
+     * @return 更新後のウォレット応答
+     */
     @PostMapping("/daily-bonus")
     public ResponseEntity<WalletResponse> claimDailyBonus(@AuthenticationPrincipal UserDetails principal) {
         if (principal == null) {
@@ -64,6 +86,12 @@ public class WalletController {
         return ResponseEntity.ok(loadWalletResponse(username));
     }
 
+    /**
+     * 救済ボーナスを請求します。
+     *
+     * @param principal 認証済みユーザー
+     * @return 更新後のウォレット応答
+     */
     @PostMapping("/recovery")
     public ResponseEntity<WalletResponse> claimRecovery(@AuthenticationPrincipal UserDetails principal) {
         if (principal == null) {
@@ -80,6 +108,9 @@ public class WalletController {
     }
 }
 
+/**
+ * Spring の {@code @RestController} として管理者向けウォレット付与 API を提供するコントローラです。
+ */
 @RestController
 @Profile("postgresql")
 @RequestMapping("/v1/admin")
@@ -91,6 +122,13 @@ class AdminWalletController {
         this.walletService = walletService;
     }
 
+    /**
+     * 管理者権限でウォレット残高を付与します。
+     *
+     * @param principal 認証済みユーザー
+     * @param request 付与リクエスト
+     * @return 更新後のウォレット応答
+     */
     @PostMapping("/wallet/grants")
     public ResponseEntity<WalletResponse> grantWalletBalance(
             @AuthenticationPrincipal UserDetails principal,

--- a/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/ActionsResponse.java
+++ b/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/ActionsResponse.java
@@ -6,7 +6,20 @@ import com.mapoker.domain.rules.ActionType;
 
 import java.util.List;
 
+/**
+ * アクション履歴レスポンスです。
+ *
+ * @param actions アクション一覧
+ */
 public record ActionsResponse(List<ActionDto> actions) {
+    /**
+     * 単一アクションの表示 DTO です。
+     *
+     * @param seq 連番
+     * @param playerIndex プレイヤー位置
+     * @param type 行動種別
+     * @param amount 金額
+     */
     public record ActionDto(
             int seq,
             @JsonProperty("player_index") int playerIndex,
@@ -14,6 +27,12 @@ public record ActionsResponse(List<ActionDto> actions) {
             int amount
     ) {}
 
+    /**
+     * アプリケーション層の履歴からレスポンスを生成します。
+     *
+     * @param records アクション履歴
+     * @return 生成したレスポンス
+     */
     public static ActionsResponse from(List<ActionRecord> records) {
         List<ActionDto> dtos = records.stream()
                 .map(r -> new ActionDto(r.seq(), r.playerIndex(), r.actionType(), r.amount()))

--- a/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/AdminGrantRequest.java
+++ b/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/AdminGrantRequest.java
@@ -4,6 +4,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
 
+/**
+ * 管理者による残高付与リクエストです。
+ *
+ * @param targetUsername 付与対象ユーザー名
+ * @param amount 付与額
+ */
 public record AdminGrantRequest(
         @JsonProperty("target_username") @NotBlank String targetUsername,
         @JsonProperty("amount") @Positive long amount

--- a/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/ApplyActionRequest.java
+++ b/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/ApplyActionRequest.java
@@ -7,10 +7,22 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 
+/**
+ * 行動適用リクエストです。
+ *
+ * @param playerIndex 行動するプレイヤー位置
+ * @param action 実行する行動
+ */
 public record ApplyActionRequest(
         @JsonProperty("player_index") @Min(0) int playerIndex,
         @NotNull @Valid ActionDto action
 ) {
+    /**
+     * 行動内容 DTO です。
+     *
+     * @param type 行動種別
+     * @param amount 行動金額
+     */
     public record ActionDto(
             @NotNull ActionType type,
             @PositiveOrZero int amount

--- a/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/CreateGameRequest.java
+++ b/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/CreateGameRequest.java
@@ -11,6 +11,15 @@ import jakarta.validation.constraints.Positive;
 
 import java.util.List;
 
+/**
+ * ゲーム作成リクエストです。
+ *
+ * @param players プレイヤー一覧
+ * @param buttonIndex ボタン位置
+ * @param bigBlind ビッグブラインド額
+ * @param seed 乱数シード
+ * @param oddChipRule 端数チップルール
+ */
 public record CreateGameRequest(
         @NotEmpty List<@Valid PlayerDto> players,
         @JsonProperty("button_index") @Min(0) int buttonIndex,
@@ -18,6 +27,12 @@ public record CreateGameRequest(
         Long seed,
         @JsonProperty("odd_chip_rule") OddChipRule oddChipRule
 ) {
+    /**
+     * ゲーム作成時のプレイヤー DTO です。
+     *
+     * @param id プレイヤー ID
+     * @param stack 初期スタック
+     */
     public record PlayerDto(
             @NotBlank String id,
             @Positive int stack

--- a/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/CreateTableRequest.java
+++ b/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/CreateTableRequest.java
@@ -10,6 +10,16 @@ import org.springframework.lang.Nullable;
 
 import java.util.List;
 
+/**
+ * テーブル作成リクエストです。
+ *
+ * @param tableName テーブル名
+ * @param playerCount プレイヤー人数
+ * @param smallBlind スモールブラインド額
+ * @param bigBlind ビッグブラインド額
+ * @param visibility 公開設定
+ * @param flags テーブル属性の一覧
+ */
 public record CreateTableRequest(
         @JsonProperty("table_name") @Size(max = 100) String tableName,
         @JsonProperty("player_count") @Min(2) @Max(9) int playerCount,

--- a/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/ErrorResponse.java
+++ b/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/ErrorResponse.java
@@ -1,8 +1,26 @@
 package com.mapoker.interfaces.http.dto;
 
+/**
+ * API エラーレスポンスです。
+ *
+ * @param error エラー詳細
+ */
 public record ErrorResponse(ErrorDetail error) {
+    /**
+     * エラー詳細 DTO です。
+     *
+     * @param code エラーコード
+     * @param message エラーメッセージ
+     */
     public record ErrorDetail(String code, String message) {}
 
+    /**
+     * エラーコードとメッセージからレスポンスを生成します。
+     *
+     * @param code エラーコード
+     * @param message エラーメッセージ
+     * @return 生成したエラーレスポンス
+     */
     public static ErrorResponse of(String code, String message) {
         return new ErrorResponse(new ErrorDetail(code, message));
     }

--- a/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/GameResponse.java
+++ b/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/GameResponse.java
@@ -15,6 +15,28 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+/**
+ * ゲーム状態レスポンスです。
+ *
+ * @param id ゲーム ID
+ * @param status ゲーム状態
+ * @param street 現在ストリート
+ * @param buttonIndex ボタン位置
+ * @param smallBlindIdx スモールブラインド位置
+ * @param bigBlindIdx ビッグブラインド位置
+ * @param currentPlayer 現在アクション中のプレイヤー位置
+ * @param currentBet 現在ベット額
+ * @param lastRaiseSize 直近レイズ幅
+ * @param bigBlind ビッグブラインド額
+ * @param potTotal ポット総額
+ * @param players プレイヤー一覧
+ * @param community コミュニティカード
+ * @param oddChipRule 端数チップルール
+ * @param canStartHand ハンド開始可否
+ * @param viewerMembershipActive 閲覧者の参加状態
+ * @param canRebuy リバイ可否
+ * @param lastShowdown 直近ショーダウン結果
+ */
 public record GameResponse(
         String id,
         GameStatus status,
@@ -35,6 +57,16 @@ public record GameResponse(
         @JsonProperty("can_rebuy") boolean canRebuy,
         @JsonProperty("last_showdown") ShowdownDto lastShowdown
 ) {
+    /**
+     * プレイヤー表示 DTO です。
+     *
+     * @param id プレイヤー ID
+     * @param stack 現在スタック
+     * @param contributed 現ストリート拠出額
+     * @param folded フォールド済みかどうか
+     * @param allIn オールイン状態かどうか
+     * @param hole ホールカード
+     */
     public record PlayerResponse(
             String id,
             int stack,
@@ -44,14 +76,35 @@ public record GameResponse(
             List<Card> hole
     ) {}
 
+    /**
+     * ショーダウン表示 DTO です。
+     *
+     * @param winners 勝者一覧
+     * @param bestHand 最良ハンド
+     * @param payouts 配当一覧
+     */
     public record ShowdownDto(
             List<Integer> winners,
             @JsonProperty("best_hand") BestHandDto bestHand,
             List<Integer> payouts
     ) {
+        /**
+         * 最良ハンド表示 DTO です。
+         *
+         * @param rank 役
+         * @param kickers キッカー一覧
+         */
         public record BestHandDto(HandRank rank, List<Rank> kickers) {}
     }
 
+    /**
+     * ドメイン状態からゲームレスポンスを生成します。
+     *
+     * @param g ゲーム状態
+     * @param viewerIndex 閲覧者の席番号
+     * @param spectator 観戦者かどうか
+     * @return 生成したゲームレスポンス
+     */
     public static GameResponse from(GameState g, Integer viewerIndex, boolean spectator) {
         List<PlayerResponse> playerResponses = new ArrayList<>();
         boolean showAll = g.getStatus() == GameStatus.SHOWDOWN

--- a/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/HandHistoryResponse.java
+++ b/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/HandHistoryResponse.java
@@ -5,6 +5,17 @@ import com.mapoker.application.HandHistoryEntry;
 
 import java.util.List;
 
+/**
+ * ハンド履歴レスポンスです。
+ *
+ * @param tableId テーブル ID
+ * @param handId ハンド ID
+ * @param players プレイヤー一覧
+ * @param winners 勝者一覧
+ * @param pot ポット額
+ * @param street 終了ストリート
+ * @param finishedAt 終了日時
+ */
 public record HandHistoryResponse(
         @JsonProperty("table_id") String tableId,
         @JsonProperty("hand_id") String handId,
@@ -14,6 +25,16 @@ public record HandHistoryResponse(
         String street,
         @JsonProperty("finished_at") String finishedAt
 ) {
+    /**
+     * ハンド履歴内プレイヤー表示 DTO です。
+     *
+     * @param name プレイヤー名
+     * @param seatIndex 着席位置
+     * @param stackBefore 開始前スタック
+     * @param stackAfter 終了後スタック
+     * @param folded フォールド済みかどうか
+     * @param holeCards ホールカード文字列表現
+     */
     public record PlayerResponse(
             String name,
             @JsonProperty("seat_index") int seatIndex,
@@ -23,6 +44,12 @@ public record HandHistoryResponse(
             @JsonProperty("hole_cards") List<String> holeCards
     ) {}
 
+    /**
+     * アプリケーション層の履歴からレスポンスを生成します。
+     *
+     * @param entry ハンド履歴
+     * @return 生成したレスポンス
+     */
     public static HandHistoryResponse from(HandHistoryEntry entry) {
         return new HandHistoryResponse(
                 entry.tableId(),

--- a/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/LoginRequest.java
+++ b/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/LoginRequest.java
@@ -3,6 +3,12 @@ package com.mapoker.interfaces.http.dto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+/**
+ * ログインリクエストです。
+ *
+ * @param username ユーザー名
+ * @param password パスワード
+ */
 public record LoginRequest(
         @NotBlank @Size(min = 3, max = 50) String username,
         @NotBlank @Size(min = 8, max = 100) String password

--- a/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/RegisterRequest.java
+++ b/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/RegisterRequest.java
@@ -3,6 +3,12 @@ package com.mapoker.interfaces.http.dto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+/**
+ * ユーザー登録リクエストです。
+ *
+ * @param username ユーザー名
+ * @param password パスワード
+ */
 public record RegisterRequest(
         @NotBlank @Size(min = 3, max = 50) String username,
         @NotBlank @Size(min = 8, max = 100) String password) {}

--- a/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/ShowdownResponse.java
+++ b/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/ShowdownResponse.java
@@ -7,13 +7,32 @@ import com.mapoker.domain.card.Rank;
 
 import java.util.List;
 
+/**
+ * ショーダウン結果レスポンスです。
+ *
+ * @param winners 勝者一覧
+ * @param bestHand 最良ハンド
+ * @param payouts 配当一覧
+ */
 public record ShowdownResponse(
         List<Integer> winners,
         @JsonProperty("best_hand") BestHandDto bestHand,
         List<Integer> payouts
 ) {
+    /**
+     * 最良ハンド表示 DTO です。
+     *
+     * @param rank 役
+     * @param kickers キッカー一覧
+     */
     public record BestHandDto(HandRank rank, List<Rank> kickers) {}
 
+    /**
+     * ドメイン結果からレスポンスを生成します。
+     *
+     * @param r ショーダウン結果
+     * @return 生成したレスポンス
+     */
     public static ShowdownResponse from(ShowdownResult r) {
         return new ShowdownResponse(
                 r.winnerIndexes(),

--- a/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/StartHandRequest.java
+++ b/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/StartHandRequest.java
@@ -3,4 +3,9 @@ package com.mapoker.interfaces.http.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.Positive;
 
+/**
+ * ハンド開始リクエストです。
+ *
+ * @param bigBlind ビッグブラインド額
+ */
 public record StartHandRequest(@JsonProperty("big_blind") @Positive int bigBlind) {}

--- a/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/TableMembershipRequest.java
+++ b/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/TableMembershipRequest.java
@@ -4,6 +4,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Size;
 
+/**
+ * テーブル参加・退出時の名義指定リクエストです。
+ *
+ * @param name 参加者名
+ * @param buyIn バイイン額
+ */
 public record TableMembershipRequest(
         @Size(max = 50) String name,
         @JsonProperty("buy_in") @Min(0) Integer buyIn

--- a/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/TableResponse.java
+++ b/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/TableResponse.java
@@ -6,6 +6,26 @@ import com.mapoker.application.TableRecord;
 
 import java.util.List;
 
+/**
+ * テーブル状態レスポンスです。
+ *
+ * @param id テーブル ID
+ * @param roomId ルーム ID
+ * @param name テーブル名
+ * @param gameType ゲーム種別
+ * @param stake ブラインド情報
+ * @param minBuyIn 最小バイイン額
+ * @param maxBuyIn 最大バイイン額
+ * @param maxPlayers 最大参加人数
+ * @param flags テーブル属性一覧
+ * @param visibility 公開設定
+ * @param status テーブル状態
+ * @param gameId ゲーム ID
+ * @param createdAt 作成日時
+ * @param memberCount 参加者数
+ * @param members 参加者一覧
+ * @param game 紐づくゲーム情報
+ */
 public record TableResponse(
         String id,
         @JsonProperty("room_id") String roomId,
@@ -24,11 +44,25 @@ public record TableResponse(
         List<MemberDto> members,
         GameResponse game
 ) {
+    /**
+     * ブラインド情報 DTO です。
+     *
+     * @param smallBlind スモールブラインド額
+     * @param bigBlind ビッグブラインド額
+     */
     public record StakeDto(
             @JsonProperty("small_blind") int smallBlind,
             @JsonProperty("big_blind") int bigBlind
     ) {}
 
+    /**
+     * 参加者表示 DTO です。
+     *
+     * @param name 参加者名
+     * @param seatIndex 着席位置
+     * @param joinedAt 参加日時
+     * @param pendingLeave 離席待ちかどうか
+     */
     public record MemberDto(
             String name,
             @JsonProperty("seat_index") int seatIndex,
@@ -36,6 +70,14 @@ public record TableResponse(
             @JsonProperty("pending_leave") boolean pendingLeave
     ) {}
 
+    /**
+     * テーブル情報からレスポンスを生成します。
+     *
+     * @param table テーブル情報
+     * @param members 参加者一覧
+     * @param game ゲーム情報
+     * @return 生成したレスポンス
+     */
     public static TableResponse from(TableRecord table, List<TableMemberRecord> members, GameResponse game) {
         List<MemberDto> memberDtos = members == null
                 ? List.of()

--- a/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/UserResponse.java
+++ b/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/UserResponse.java
@@ -1,3 +1,9 @@
 package com.mapoker.interfaces.http.dto;
 
+/**
+ * ユーザー表示レスポンスです。
+ *
+ * @param id ユーザー ID
+ * @param username ユーザー名
+ */
 public record UserResponse(long id, String username) {}

--- a/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/UserTableHistoryResponse.java
+++ b/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/UserTableHistoryResponse.java
@@ -6,6 +6,19 @@ import com.mapoker.application.UserTableHistoryEntry;
 
 import java.util.List;
 
+/**
+ * ユーザーのテーブル参加履歴レスポンスです。
+ *
+ * @param tableId テーブル ID
+ * @param tableName テーブル名
+ * @param seatIndex 着席位置
+ * @param visibility 公開設定
+ * @param status テーブル状態
+ * @param flags テーブル属性一覧
+ * @param joinedAt 参加日時
+ * @param leftAt 退出日時
+ * @param active 現在も参加中かどうか
+ */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record UserTableHistoryResponse(
         @JsonProperty("table_id") String tableId,
@@ -18,6 +31,12 @@ public record UserTableHistoryResponse(
         @JsonProperty("left_at") String leftAt,
         boolean active
 ) {
+    /**
+     * 参加履歴からレスポンスを生成します。
+     *
+     * @param entry 参加履歴
+     * @return 生成したレスポンス
+     */
     public static UserTableHistoryResponse from(UserTableHistoryEntry entry) {
         return new UserTableHistoryResponse(
                 entry.tableId(),

--- a/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/WalletLedgerResponse.java
+++ b/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/WalletLedgerResponse.java
@@ -5,6 +5,17 @@ import com.mapoker.application.WalletLedgerEntry;
 
 import java.time.Instant;
 
+/**
+ * ウォレット台帳レスポンスです。
+ *
+ * @param id 台帳 ID
+ * @param delta 増減量
+ * @param balanceAfter 反映後残高
+ * @param reason 取引理由
+ * @param referenceType 参照種別
+ * @param referenceId 参照 ID
+ * @param createdAt 作成日時
+ */
 public record WalletLedgerResponse(
         @JsonProperty("id") long id,
         @JsonProperty("delta") long delta,
@@ -14,6 +25,12 @@ public record WalletLedgerResponse(
         @JsonProperty("reference_id") String referenceId,
         @JsonProperty("created_at") Instant createdAt
 ) {
+    /**
+     * 台帳エントリからレスポンスを生成します。
+     *
+     * @param entry 台帳エントリ
+     * @return 生成したレスポンス
+     */
     public static WalletLedgerResponse from(WalletLedgerEntry entry) {
         return new WalletLedgerResponse(
                 entry.id(),

--- a/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/WalletResponse.java
+++ b/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/WalletResponse.java
@@ -6,11 +6,25 @@ import com.mapoker.application.WalletService;
 
 import java.time.Instant;
 
+/**
+ * ウォレット残高レスポンスです。
+ *
+ * @param chipBalance チップ残高
+ * @param nextDailyBonusAt 次回日次ボーナス可能時刻
+ * @param nextRecoveryAt 次回救済ボーナス可能時刻
+ */
 public record WalletResponse(
         @JsonProperty("chip_balance") long chipBalance,
         @JsonProperty("next_daily_bonus_at") Instant nextDailyBonusAt,
         @JsonProperty("next_recovery_at") Instant nextRecoveryAt
 ) {
+    /**
+     * ウォレット情報からレスポンスを生成します。
+     *
+     * @param walletEntry ウォレット情報
+     * @param nextClaimTimes 次回請求可能時刻
+     * @return 生成したレスポンス
+     */
     public static WalletResponse from(WalletEntry walletEntry, WalletService.NextClaimTimes nextClaimTimes) {
         return new WalletResponse(
                 walletEntry.chipBalance(),

--- a/mapoker-backend/src/main/java/com/mapoker/interfaces/http/filter/LoginRateLimitFilter.java
+++ b/mapoker-backend/src/main/java/com/mapoker/interfaces/http/filter/LoginRateLimitFilter.java
@@ -12,6 +12,9 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.ConcurrentHashMap;
 
+/**
+ * ログインエンドポイントへのアクセス頻度を制限するフィルタです。
+ */
 public class LoginRateLimitFilter extends OncePerRequestFilter {
 
     private static final int MAX_REQUESTS_PER_MINUTE = 10;

--- a/mapoker-backend/src/main/java/com/mapoker/mapoker/MapokerApplication.java
+++ b/mapoker-backend/src/main/java/com/mapoker/mapoker/MapokerApplication.java
@@ -1,4 +1,9 @@
 package com.mapoker.mapoker;
 
+/**
+ * プレースホルダークラス。実際のエントリポイントは {@link com.mapoker.MapokerApplication} を参照。
+ *
+ * <p>このクラスはパッケージ構成の都合で存在するが、アプリケーションの起動には使用されない。
+ */
 // Placeholder — entry point is com.mapoker.MapokerApplication
 public class MapokerApplication {}


### PR DESCRIPTION
## Summary
- バックエンド全 79 ファイル・全公開クラス／メソッド／フィールドに日本語 Javadoc を付与
- Codex で生成、Claude でレビュー・補完（`Player` コンストラクタの欠落を追記）
- ロジック変更なし、Javadoc コメント追加のみ

## 変更方針
- 言語: 日本語
- クラス/インタフェース: 責務・用途を 1〜3 文で説明
- メソッド: `@param` / `@return` / `@throws` を必要に応じて付与
- フィールド・定数: 値の意味を 1 行コメントで記載
- record コンポーネント: クラス Javadoc の `@param` で説明
- Spring 管理クラス: Spring での役割（`@Service` / `@Repository` など）を明記
- 自明な getter/setter・enum `getLabel()` は省略

## Test plan
- [ ] ロジック変更なしのため既存テストがそのままパスすること
- [ ] `./mvnw spotless:check` でフォーマット違反がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)