### PR TITLE
fix(ci): ghcr.io イメージタグのオーナー名を lowercase に変換

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set version
+      - name: Set version and owner
         id: version
-        run: echo "VERSION=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
+        run: |
+          echo "VERSION=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
+          echo "OWNER=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -35,8 +37,8 @@ jobs:
           context: mapoker-backend
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/mapoker-backend:${{ steps.version.outputs.VERSION }}
-            ghcr.io/${{ github.repository_owner }}/mapoker-backend:latest
+            ghcr.io/${{ steps.version.outputs.OWNER }}/mapoker-backend:${{ steps.version.outputs.VERSION }}
+            ghcr.io/${{ steps.version.outputs.OWNER }}/mapoker-backend:latest
 
       - name: Build & push frontend image
         uses: docker/build-push-action@v5
@@ -44,8 +46,8 @@ jobs:
           context: mapoker-frontend
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/mapoker-frontend:${{ steps.version.outputs.VERSION }}
-            ghcr.io/${{ github.repository_owner }}/mapoker-frontend:latest
+            ghcr.io/${{ steps.version.outputs.OWNER }}/mapoker-frontend:${{ steps.version.outputs.VERSION }}
+            ghcr.io/${{ steps.version.outputs.OWNER }}/mapoker-frontend:latest
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
ghcr.io はリポジトリ名が lowercase 必須だが `github.repository_owner` が `Taiki2523` のため失敗していた。`tr '[:upper:]' '[:lower:]'` で変換するステップを追加。