### PR TITLE
fix: ゲームプレイ複数バグ修正 — 自動開始・アニメーション・ショーダウン・リバイ

### DIFF
--- a/mapoker-backend/src/main/java/com/mapoker/application/TableService.java
+++ b/mapoker-backend/src/main/java/com/mapoker/application/TableService.java
@@ -230,7 +230,7 @@ public class TableService {
                         if (buyIn < table.minBuyIn() || buyIn > table.maxBuyIn()) {
                             throw new IllegalArgumentException("buy-in out of range");
                         }
-                        walletService.buyIn(name, table.id(), buyIn);
+                        walletService.rebuy(name, table.id(), buyIn);
                     }
                     gameService.setSeatStack(table.gameId(), existing.seatIndex(), buyIn);
                     gameService.setSittingOut(table.gameId(), existing.seatIndex(), false);
@@ -238,6 +238,7 @@ public class TableService {
                 userTableHistoryService.recordJoin(name, table, existing.seatIndex());
                 result = new JoinResult(existing.seatIndex(), List.copyOf(members));
                 publishMembers(table.id(), result.members());
+                publishGameState(table.id(), table.gameId());
                 return result;
             }
 
@@ -284,6 +285,7 @@ public class TableService {
             userTableHistoryService.recordJoin(name, table, seatIndex);
             result = new JoinResult(seatIndex, List.copyOf(members));
             publishMembers(table.id(), result.members());
+            publishGameState(table.id(), table.gameId());
             return result;
         }
     }
@@ -378,6 +380,13 @@ public class TableService {
         GameEventPublisher pub = eventPublisherProvider.getIfAvailable();
         if (pub != null) {
             pub.publishMembers(tableId, members);
+        }
+    }
+
+    private void publishGameState(String tableId, String gameId) {
+        GameEventPublisher pub = eventPublisherProvider.getIfAvailable();
+        if (pub != null) {
+            pub.publishGameState(tableId, gameService.getGame(gameId));
         }
     }
 

--- a/mapoker-backend/src/main/java/com/mapoker/application/WalletService.java
+++ b/mapoker-backend/src/main/java/com/mapoker/application/WalletService.java
@@ -19,6 +19,7 @@ public class WalletService {
     private static final String DAILY_BONUS = "DAILY_BONUS";
     private static final String RECOVERY_BONUS = "RECOVERY_BONUS";
     private static final String TABLE_BUY_IN = "TABLE_BUY_IN";
+    private static final String TABLE_REBUY = "TABLE_REBUY";
     private static final String TABLE_CASH_OUT = "TABLE_CASH_OUT";
     private static final String ADMIN_GRANT = "ADMIN_GRANT";
 
@@ -107,6 +108,32 @@ public class WalletService {
                 "TABLE",
                 normalizedTableId,
                 "BUY_IN:" + normalizedTableId + ":" + normalizedUsername)) {
+            throw new IllegalStateException("insufficient funds");
+        }
+    }
+
+    /**
+     * リバイのためにウォレットからチップを引き落とします。
+     * 初回バイインとは別の idempotency キーを使い、複数回のリバイを正しく処理します。
+     *
+     * @param username ユーザー名
+     * @param tableId テーブル ID
+     * @param amount 引き落とし額
+     * @throws IllegalArgumentException 入力値が不正な場合
+     * @throws IllegalStateException 残高不足の場合
+     */
+    public void rebuy(String username, String tableId, int amount) {
+        String normalizedUsername = requireUsername(username);
+        String normalizedTableId = normalizeReference(tableId);
+        validateAmount(amount);
+        String idempotencyKey = "REBUY:" + normalizedTableId + ":" + normalizedUsername + ":" + Instant.now().toEpochMilli();
+        if (!walletRepository.debit(
+                normalizedUsername,
+                amount,
+                TABLE_REBUY,
+                "TABLE",
+                normalizedTableId,
+                idempotencyKey)) {
             throw new IllegalStateException("insufficient funds");
         }
     }

--- a/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/GameResponse.java
+++ b/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/GameResponse.java
@@ -110,10 +110,13 @@ public record GameResponse(
         boolean showAll = g.getStatus() == GameStatus.SHOWDOWN
                 || (g.getStatus() == GameStatus.FINISHED && !g.isFoldWin());
 
+        boolean isFinished = g.getStatus() == GameStatus.FINISHED;
         for (int i = 0; i < g.getPlayers().size(); i++) {
             Player p = g.getPlayers().get(i);
             List<Card> hole = null;
-            if (showAll && p.getHole() != null && p.getHole()[0] != null) {
+            boolean showThisPlayer = showAll
+                    || (isFinished && p.isAllIn() && !p.isFolded());
+            if (showThisPlayer && p.getHole() != null && p.getHole()[0] != null) {
                 hole = Arrays.asList(p.getHole());
             } else if (!spectator && viewerIndex != null && viewerIndex == i) {
                 hole = p.getHole() != null ? Arrays.asList(p.getHole()) : List.of();

--- a/mapoker-backend/src/main/resources/db/migration/V8__add_rebuy_reason.sql
+++ b/mapoker-backend/src/main/resources/db/migration/V8__add_rebuy_reason.sql
@@ -1,0 +1,1 @@
+ALTER TYPE wallet_ledger_reason ADD VALUE IF NOT EXISTS 'TABLE_REBUY';

--- a/mapoker-frontend/src/App.tsx
+++ b/mapoker-frontend/src/App.tsx
@@ -283,7 +283,8 @@ function App() {
   }, [game, showdown])
 
   useEffect(() => {
-    if (!game || game.status !== 'finished' || !game.can_start_hand) return
+    const isAutoStartable = game?.status === 'finished' || !game?.status
+    if (!game || !isAutoStartable || !game.can_start_hand) return
     const timer = window.setTimeout(() => {
       void startHand(undefined, undefined, { suppressError: true })
     }, NEXT_HAND_DELAY_MS)

--- a/mapoker-frontend/src/components/GameScreen/TableArea.tsx
+++ b/mapoker-frontend/src/components/GameScreen/TableArea.tsx
@@ -47,6 +47,8 @@ export function TableArea({
   const prevHoleRef = useRef<Record<number, number>>({})
   // StrictMode 対応: cleanup で元の値に戻すため prevCommLenRef をマウント時の枚数で初期化
   const prevCommLenRef = useRef(_initCommCount)
+  // ショーダウン開始時点（ペイアウト前）のスタックを凍結し、result 表示まで旧値を見せる
+  const frozenStacksRef = useRef<number[] | null>(null)
   const prevContribRef = useRef<Record<number, number>>({})
   const cardAnimEndsAtRef = useRef(0)
   const [dealingSeats, setDealingSeats] = useState<Set<number>>(new Set())
@@ -93,7 +95,9 @@ export function TableArea({
 
   // コミュニティカードの公開順序制御
   //
-  // StrictMode 対応: cleanup で prevCommLenRef を元の値（prev）に戻す。
+  // prevCommLenRef は effect 本体ではなく各タイマーコールバック内で更新する。
+  // こうすることで cleanup がタイマーをキャンセルしても ref が巻き戻らず、
+  // 次の effect が正しい prev を参照できる（StrictMode でも production でも動作する）。
   useEffect(() => {
     const current = communityCount
     const prev = prevCommLenRef.current
@@ -104,8 +108,6 @@ export function TableArea({
       return
     }
 
-    prevCommLenRef.current = current
-
     const timers: number[] = []
     let delay = 0
 
@@ -114,6 +116,7 @@ export function TableArea({
       const revealTo = Math.min(current, 3)
       const flopSet = new Set(Array.from({ length: revealTo - prev }, (_, i) => prev + i))
       timers.push(window.setTimeout(() => {
+        prevCommLenRef.current = Math.max(prevCommLenRef.current, revealTo)
         setRevealedCount(revealTo)
         setFlippingIndices(flopSet)
       }, delay))
@@ -124,6 +127,7 @@ export function TableArea({
     // ターン（インデックス 3）
     if (prev < 4 && current >= 4) {
       timers.push(window.setTimeout(() => {
+        prevCommLenRef.current = Math.max(prevCommLenRef.current, 4)
         setRevealedCount(4)
         setFlippingIndices(new Set([3]))
       }, delay))
@@ -134,6 +138,7 @@ export function TableArea({
     // リバー（インデックス 4）
     if (prev < 5 && current >= 5) {
       timers.push(window.setTimeout(() => {
+        prevCommLenRef.current = Math.max(prevCommLenRef.current, 5)
         setRevealedCount(5)
         setFlippingIndices(new Set([4]))
       }, delay))
@@ -144,12 +149,23 @@ export function TableArea({
     cardAnimEndsAtRef.current = Date.now() + delay
 
     return () => {
-      prevCommLenRef.current = prev  // StrictMode: 2回目の実行で再スケジュールできるよう戻す
       cardAnimEndsAtRef.current = 0
       setFlippingIndices(new Set())
       timers.forEach(window.clearTimeout)
     }
   }, [communityCount])
+
+  // ショーダウン開始時点のスタックを凍結（ペイアウト前の値を保持）
+  useEffect(() => {
+    if (isShowdown) {
+      if (frozenStacksRef.current === null) {
+        frozenStacksRef.current = game.players.map((p) => p.stack)
+      }
+    } else {
+      frozenStacksRef.current = null
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isShowdown])
 
   // ショーダウン結果のオーバーレイ表示（カードアニメーション完了後に開始）
   // setSdStep は setTimeout 経由で呼ぶ（react-hooks/set-state-in-effect 対策）
@@ -337,7 +353,11 @@ export function TableArea({
                         </div>
                       </div>
                       <div className="player-stack">
-                        Stack <strong>{formatStack(player.stack)}</strong>
+                        Stack <strong>{formatStack(
+                          showResult || frozenStacksRef.current === null
+                            ? player.stack
+                            : (frozenStacksRef.current[idx] ?? player.stack)
+                        )}</strong>
                       </div>
                     </div>
                   </div>

--- a/mapoker-frontend/src/i18n.ts
+++ b/mapoker-frontend/src/i18n.ts
@@ -197,6 +197,7 @@ const ja = {
   RECOVERY_BONUS: '回復チップ',
   ADMIN_GRANT: '管理者付与',
   TABLE_BUY_IN: 'バイイン',
+  TABLE_REBUY: 'リバイ',
   TABLE_CASH_OUT: 'キャッシュアウト',
   cooldownUntil: '次回: {time}',
   insufficientFunds: 'チップが不足しています',


### PR DESCRIPTION
## Summary

- **2人目着席時に自動開始しない**: `TableService.join()` 後に `publishGameState` を追加して `can_start_hand` の変化を全クライアントへ伝播。フロントの auto-start 条件を `status=null`（初回ハンド）にも対応
- **turn/river 開幕時に flop へロールバックされるアニメーションバグ**: `TableArea` の cleanup が `prevCommLenRef` をリセットしていたため次 effect が `prev=0` と誤認。ref 更新をタイマーコールバック内に移動して修正
- **ショーダウン result 表示前にスタックが変動**: `isShowdown` 開始時点のスタックを `frozenStacksRef` に保存し `sdStep>=3`（result 表示後）まで旧値を表示
- **オールイン参加プレイヤーのカードがショーダウンで非表示**: fold-win 時も `player.isAllIn()` なら hole cards を公開するよう `GameResponse.from()` を修正
- **リバイ時にウォレット残高が減らない**: `buyIn()` の idempotency key が初回バイインと同一でデビットがスキップされていた。`rebuy()` を追加してタイムスタンプ付き固有 key を使用。V8 migration で `TABLE_REBUY` reason を DB に追加
- **増減履歴にリバイを区別表示**: i18n に `TABLE_REBUY: 'リバイ'` を追加

## Test plan

- [ ] テーブルに2人着席 → 7秒後に自動でハンドが始まること
- [ ] フロップ後のターン/リバーでカードがスムーズに公開されること（flop ロールバックなし）
- [ ] ショーダウン: result overlay が出るまでスタック表示が変わらないこと
- [ ] オールイン → fold-win でオールインプレイヤーのカードが表示されること
- [ ] リバイ後に所持チップが正しく減ること
- [ ] 増減履歴にバイイン / リバイ / キャッシュアウトが正しく表示されること
- [ ] `./mvnw test` が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)