### PR TITLE
fix: ミニマムレイズを 2x current_bet ルールに変更 (v1.0.1)

### DIFF
--- a/mapoker-backend/pom.xml
+++ b/mapoker-backend/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.mapoker</groupId>
 	<artifactId>mapoker-backend</artifactId>
-	<version>1.0.0</version>
+	<version>1.0.1</version>
 	<name/>
 	<description/>
 	<url/>

--- a/mapoker-backend/src/main/java/com/mapoker/domain/game/GameState.java
+++ b/mapoker-backend/src/main/java/com/mapoker/domain/game/GameState.java
@@ -247,9 +247,9 @@ public class GameState {
                 commitBet(playerIndex, target);
                 if (target > currentBet) {
                     int raiseSize = target - currentBet;
-                    int previousRaise = lastRaiseSize;
+                    int previousBet = currentBet;
                     currentBet = target;
-                    if (raiseSize >= minRaiseSize(bigBlindSize, previousRaise)) {
+                    if (raiseSize >= minRaiseSize(bigBlindSize, previousBet)) {
                         lastRaiseSize = raiseSize;
                         raiseOpen = true;
                         resetActedExcept(playerIndex);

--- a/mapoker-backend/src/main/java/com/mapoker/domain/rules/ActionValidator.java
+++ b/mapoker-backend/src/main/java/com/mapoker/domain/rules/ActionValidator.java
@@ -67,7 +67,7 @@ public final class ActionValidator {
     }
 
     private static int minRaiseSize(TableState table) {
-        return Math.max(table.lastRaiseSize(), table.bigBlind());
+        return Math.max(table.currentBet(), table.bigBlind());
     }
 
     private static int currentToCall(TableState table, PlayerState player) {

--- a/mapoker-frontend/package.json
+++ b/mapoker-frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite --host 0.0.0.0 --port 5173",

--- a/mapoker-frontend/src/App.tsx
+++ b/mapoker-frontend/src/App.tsx
@@ -120,7 +120,7 @@ function App() {
   const minRaise = useMemo(() => {
     if (!game) return 0
     if (game.current_bet === 0) return game.big_blind
-    return game.current_bet + Math.max(game.big_blind, game.last_raise_size || game.big_blind)
+    return game.current_bet * 2
   }, [game])
 
   const maxBet = useMemo(() => {


### PR DESCRIPTION
## Summary

- ミニマムレイズルールを **raise-to = 2 × current_bet** に変更
- プリフロップ・フロップ・ターン・リバー全ストリートに適用

| 状況 (BB=10) | 変更前 min raise-to | 変更後 min raise-to |
|---|---|---|
| 初回レイズ | \$20 | \$20（変わらず） |
| \$20 へのレイズ後 re-raise | \$30 | **\$40** |
| \$30 へのレイズ後 re-raise | \$50 | **\$60** |

## Changes

- `ActionValidator.java` — `minRaiseSize`: `lastRaiseSize` → `currentBet` ベースに変更
- `GameState.java` — ALL_IN の raiseOpen 判定を `previousBet`（ALL_IN 前の currentBet）で評価
- `App.tsx` — `minRaise = current_bet * 2`

## Test plan

- [ ] `./mvnw test` が通ること
- [ ] BB=\$10 での初回レイズ minimum が \$20 のまま
- [ ] \$20 へのレイズ後の min re-raise が \$40 になること（\$30 ではない）
- [ ] フロップ/ターン/リバーでも同じルールが適用されること
- [ ] sub-min all-in で raiseOpen=false のままであること

🤖 Generated with [Claude Code](https://claude.com/claude-code)