### PR TITLE
fix: アクション吹き出し・AI表示・プリセット・サイドポット修正 (v1.0.2)

### DIFF
--- a/mapoker-backend/pom.xml
+++ b/mapoker-backend/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.mapoker</groupId>
 	<artifactId>mapoker-backend</artifactId>
-	<version>1.0.1</version>
+	<version>1.0.2</version>
 	<name/>
 	<description/>
 	<url/>

--- a/mapoker-backend/src/main/java/com/mapoker/domain/game/GameState.java
+++ b/mapoker-backend/src/main/java/com/mapoker/domain/game/GameState.java
@@ -14,8 +14,10 @@ import com.mapoker.domain.rules.Street;
 import com.mapoker.domain.rules.TableState;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 
@@ -300,6 +302,7 @@ public class GameState {
         if (community.size() < PokerConstants.COMMUNITY_CARDS)
             throw new IllegalStateException("community cards incomplete");
 
+        Map<Integer, HandValue> handValues = new HashMap<>();
         HandValue best = new HandValue(HandRank.HIGH_CARD, List.of(Rank.TWO));
         List<Integer> winners = new ArrayList<>();
 
@@ -309,6 +312,7 @@ public class GameState {
             if (p.isSittingOut()) continue;
             Card[] seven = buildSeven(p.getHole(), community);
             HandValue val = HandEvaluator.eval7(seven);
+            handValues.put(i, val);
             int cmp = val.compareTo(best);
             if (cmp > 0) {
                 best = val;
@@ -321,7 +325,7 @@ public class GameState {
         if (winners.isEmpty())
             throw new IllegalStateException("no active players at showdown");
 
-        List<Integer> payouts = splitPots(winners);
+        List<Integer> payouts = splitPots(handValues);
         ShowdownResult result = new ShowdownResult(List.copyOf(winners), best, payouts);
         lastShowdown = result;
         return result;
@@ -488,6 +492,7 @@ public class GameState {
         return out;
     }
 
+    // フォールドウィン用：勝者リストを直接渡す
     private List<Integer> splitPots(List<Integer> winners) {
         int[] payouts = new int[players.size()];
         List<SidePot> pots = buildSidePots();
@@ -502,6 +507,40 @@ public class GameState {
         List<Integer> result = new ArrayList<>(players.size());
         for (int v : payouts) result.add(v);
         return result;
+    }
+
+    // ショーダウン用：サイドポットごとに eligible 内の最強ハンドを再評価する
+    private List<Integer> splitPots(Map<Integer, HandValue> handValues) {
+        int[] payouts = new int[players.size()];
+        List<SidePot> pots = buildSidePots();
+        for (SidePot sp : pots) {
+            List<Integer> potWinners = findPotWinners(sp.eligible(), handValues);
+            if (potWinners.isEmpty()) continue;
+            int base = sp.amount() / potWinners.size();
+            int rem = sp.amount() % potWinners.size();
+            for (int idx : potWinners) payouts[idx] += base;
+            distributeRemainder(payouts, potWinners, rem);
+        }
+        List<Integer> result = new ArrayList<>(players.size());
+        for (int v : payouts) result.add(v);
+        return result;
+    }
+
+    private List<Integer> findPotWinners(List<Integer> eligible, Map<Integer, HandValue> handValues) {
+        HandValue best = null;
+        List<Integer> winners = new ArrayList<>();
+        for (int idx : eligible) {
+            HandValue val = handValues.get(idx);
+            if (val == null) continue;
+            if (best == null || val.compareTo(best) > 0) {
+                best = val;
+                winners.clear();
+                winners.add(idx);
+            } else if (val.compareTo(best) == 0) {
+                winners.add(idx);
+            }
+        }
+        return winners;
     }
 
     private record SidePot(int amount, List<Integer> eligible) {}

--- a/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/GameResponse.java
+++ b/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/GameResponse.java
@@ -110,12 +110,11 @@ public record GameResponse(
         boolean showAll = g.getStatus() == GameStatus.SHOWDOWN
                 || (g.getStatus() == GameStatus.FINISHED && !g.isFoldWin());
 
-        boolean isFinished = g.getStatus() == GameStatus.FINISHED;
         for (int i = 0; i < g.getPlayers().size(); i++) {
             Player p = g.getPlayers().get(i);
             List<Card> hole = null;
             boolean showThisPlayer = showAll
-                    || (isFinished && p.isAllIn() && !p.isFolded());
+                    || (p.isAllIn() && !p.isFolded());
             if (showThisPlayer && p.getHole() != null && p.getHole()[0] != null) {
                 hole = Arrays.asList(p.getHole());
             } else if (!spectator && viewerIndex != null && viewerIndex == i) {

--- a/mapoker-frontend/package.json
+++ b/mapoker-frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "scripts": {
     "dev": "vite --host 0.0.0.0 --port 5173",

--- a/mapoker-frontend/src/App.css
+++ b/mapoker-frontend/src/App.css
@@ -471,7 +471,7 @@
 }
 
 .card-suit {
-  font-size: 0.9em;
+  font-size: 1.1em;
   line-height: 1;
 }
 

--- a/mapoker-frontend/src/App.tsx
+++ b/mapoker-frontend/src/App.tsx
@@ -134,10 +134,9 @@ function App() {
     const clamp = (v: number) => Math.min(cap, Math.max(minRaise, v))
     if (game.street === 'preflop') {
       return [
-        { label: 'x1', amount: clamp(game.current_bet + (game.big_blind * 1)) },
-        { label: 'x2', amount: clamp(game.current_bet + (game.big_blind * 2)) },
-        { label: 'x3', amount: clamp(game.current_bet + (game.big_blind * 3)) },
-        { label: 'x4', amount: clamp(game.current_bet + (game.big_blind * 4)) },
+        { label: 'x2', amount: clamp(game.current_bet * 2) },
+        { label: 'x3', amount: clamp(game.current_bet * 3) },
+        { label: 'x4', amount: clamp(game.current_bet * 4) },
         { label: 'ALL', amount: maxBet },
       ]
         .filter((p) => p.amount > 0 && p.amount <= maxBet)

--- a/mapoker-frontend/src/components/GameScreen/TableArea.tsx
+++ b/mapoker-frontend/src/components/GameScreen/TableArea.tsx
@@ -215,24 +215,33 @@ export function TableArea({
     prevCurrentBetRef.current = game.current_bet
     prevStreetRef.current = game.street
 
-    if (prevPlayer < 0 || prevStreet !== game.street || prevPlayer === game.current_player) return
+    if (prevPlayer < 0) return
+    if (prevPlayer === game.current_player && prevStreet === game.street) return
 
     const actingNow = game.players[prevPlayer]
     const actingBefore = prevPlayers[prevPlayer]
     if (!actingNow || !actingBefore) return
 
+    const streetChanged = prevStreet !== game.street
     let label = ''
+
     if (actingNow.folded && !actingBefore.folded) {
       label = t('fold')
-    } else if (actingNow.all_in && actingNow.contributed > actingBefore.contributed) {
-      label = `${t('allIn')} ${formatStack(actingNow.contributed)}`
+    } else if (actingNow.all_in && !actingBefore.all_in) {
+      // 同一ストリート: contributed 増加あり → 金額付き、ストリートまたぎ: リセット済みなので金額なし
+      label = actingNow.contributed > actingBefore.contributed
+        ? `${t('allIn')} ${formatStack(actingNow.contributed)}`
+        : t('allIn')
     } else if (actingNow.contributed > actingBefore.contributed) {
+      // ストリートまたぎ時は contributed=0 にリセットされるため、このブランチは同一ストリートのみ到達
       const delta = actingNow.contributed - actingBefore.contributed
-      if (game.current_bet > prevBet) {
-        label = prevBet === 0 ? `${t('betLabel')} ${formatStack(actingNow.contributed)}` : `${t('raiseLabel')} ${formatStack(actingNow.contributed)}`
-      } else {
-        label = `${t('call')} ${formatStack(delta)}`
-      }
+      label = game.current_bet > prevBet
+        ? (prevBet === 0 ? `${t('betLabel')} ${formatStack(actingNow.contributed)}` : `${t('raiseLabel')} ${formatStack(actingNow.contributed)}`)
+        : `${t('call')} ${formatStack(delta)}`
+    } else if (streetChanged && prevBet > 0) {
+      // ストリートまたぎのコール（contributed リセット済み → prevBet で推定）
+      // ※ streetChanged なしだと BB オプションチェック（contributed 変化なし、prevBet>0）と区別できない
+      label = `${t('call')} ${formatStack(prevBet)}`
     } else {
       label = t('check')
     }
@@ -240,15 +249,20 @@ export function TableArea({
     if (!label) return
 
     const seatIdx = prevPlayer
-    setActionBubbles((prev) => new Map(prev).set(seatIdx, label))
-    const timerId = window.setTimeout(() => {
+    const showId = window.setTimeout(() => {
+      setActionBubbles((prev) => new Map(prev).set(seatIdx, label))
+    }, 1000)
+    const clearId = window.setTimeout(() => {
       setActionBubbles((prev) => {
         const next = new Map(prev)
         next.delete(seatIdx)
         return next
       })
-    }, 3000)
-    return () => window.clearTimeout(timerId)
+    }, 4000)
+    return () => {
+      window.clearTimeout(showId)
+      window.clearTimeout(clearId)
+    }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [game.current_player, game.street, game.players, game.current_bet])
 
@@ -316,6 +330,7 @@ export function TableArea({
           const isWinnerSeat = showResult && (showdown?.winners?.includes(idx) ?? false)
           const isLoserSeat = showResult && !(showdown?.winners?.includes(idx) ?? false) && !player.folded
           const showCards = mySeat === idx || isSpectator || (showResult && !player.folded)
+            || (game.status === 'in_progress' && !player.folded && player.all_in)
           const cards = player.hole?.length ? player.hole : ['--', '--']
           const isMe = mySeat === idx
 


### PR DESCRIPTION
## Summary

- **アクション吹き出しが出ないバグ**: ストリート末尾アクション（コール・チェック等）が `prevStreet !== game.street` で早期リターンしていた。`streetChanged` フラグで if-else を一本化し全ストリートで検出。全吹き出しを一律 1000ms 遅延表示に統一
- **オールイン中に相手カードが見えない**: `GameResponse.from()` で `isAllIn && !isFolded` のカードをステータス問わず公開。フロント `showCards` に `in_progress && all_in` 条件を追加
- **プリフロップ倍率バグ・x1 廃止**: プリセットを `current_bet + N*BB` → `N * current_bet` に変更、x1 廃止して x2/x3/x4/ALL に整理
- **カードマーク拡大**: `.card-suit` の font-size を `0.9em` → `1.1em`
- **マルチウェイオールインのサイドポット消滅バグ**: global winners 不在のサイドポットが `continue` でスキップされチップが消えていた。ショーダウン用に `splitPots(Map<Integer, HandValue>)` を追加し、サイドポットごとに eligible 内の最強ハンドを再評価して配分

## Test plan

- [ ] `./mvnw test` が通ること
- [ ] フロップ/ターン/リバーの最終アクション後に吹き出しが 1 秒後に表示されること
- [ ] オールイン中に相手のカードが見えること
- [ ] プリフロップ x2=$20, x3=$30, x4=$40（BB=$10 の場合）になること
- [ ] 3人以上のオールインでサイドポットが正しく配分されチップが消えないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)