### PR TITLE
feat: #59 #60 #61 #62 UI改善・退席バグ修正・アクションログ永続化

### DIFF
--- a/mapoker-backend/src/main/java/com/mapoker/MapokerApplication.java
+++ b/mapoker-backend/src/main/java/com/mapoker/MapokerApplication.java
@@ -3,6 +3,7 @@ package com.mapoker;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 /**
  * Spring Boot アプリケーションのエントリポイント。
@@ -16,6 +17,7 @@ import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
  */
 @SpringBootApplication
 @ConfigurationPropertiesScan
+@EnableScheduling
 public class MapokerApplication {
 
 	/**

--- a/mapoker-backend/src/main/java/com/mapoker/application/ActionRecord.java
+++ b/mapoker-backend/src/main/java/com/mapoker/application/ActionRecord.java
@@ -3,15 +3,22 @@ package com.mapoker.application;
 import com.mapoker.domain.rules.ActionType;
 
 /**
- * 1回のプレイヤーアクションを表す不変レコード。
+ * 1回のプレイヤーアクションまたはショーダウン/ペイアウト結果を表す不変レコード。
  *
  * <p>{@link GameRepository} への永続化および履歴取得に使用される。
- * {@code amount} の意味は {@link ActionType} によって異なる。
- * {@code bet}/{@code raise} の場合は raise-to トータル額、{@code call} の場合は 0 で自動コール。
+ * {@link ActionType#SHOWDOWN} の場合は {@code label} に役名を格納する。
+ * {@link ActionType#PAYOUT} の場合は {@code amount} に獲得チップ数を格納する。
  *
  * @param seq         ゲーム内でのアクション通し番号（1始まり）
  * @param playerIndex アクションを実行したプレイヤーのシートインデックス
  * @param actionType  アクションの種別（{@link ActionType}）
  * @param amount      アクションに伴う金額（chips）。fold / check は 0
+ * @param label       ショーダウン時の役名など補足情報（null 可）
  */
-public record ActionRecord(int seq, int playerIndex, ActionType actionType, int amount) {}
+public record ActionRecord(int seq, int playerIndex, ActionType actionType, int amount, String label) {
+
+    /** label なしの簡略コンストラクタ（既存コードとの後方互換）。 */
+    public ActionRecord(int seq, int playerIndex, ActionType actionType, int amount) {
+        this(seq, playerIndex, actionType, amount, null);
+    }
+}

--- a/mapoker-backend/src/main/java/com/mapoker/application/GameRepository.java
+++ b/mapoker-backend/src/main/java/com/mapoker/application/GameRepository.java
@@ -62,6 +62,16 @@ public interface GameRepository {
     List<GameState> findAll();
 
     /**
+     * ゲーム状態を更新せずにアクションのみを追記する。
+     *
+     * <p>ショーダウン結果・ペイアウトなど、ゲーム状態変更を伴わないログ追記に使用する。
+     *
+     * @param id     ゲーム ID
+     * @param action 追記するアクション
+     */
+    void appendAction(String id, ActionRecord action);
+
+    /**
      * 指定ゲームに記録された全アクション履歴を取得する。
      *
      * @param gameId ゲーム ID

--- a/mapoker-backend/src/main/java/com/mapoker/application/GameService.java
+++ b/mapoker-backend/src/main/java/com/mapoker/application/GameService.java
@@ -258,6 +258,26 @@ public class GameService {
         ShowdownResult result = state.resolveShowdown();
         state.applyPayouts(result.payouts());
         gameRepository.update(id, state);
+
+        // ショーダウン結果をアクションログに永続化
+        int nextSeq = gameRepository.findActionsByGameId(id).size() + 1;
+        boolean isFoldWin = result.bestHand() == null
+                || result.bestHand().rank() == null;
+        String handLabel = isFoldWin ? "fold_win" : result.bestHand().rank().getLabel();
+        // 勝者のシートインデックスを使って SHOWDOWN レコードを記録
+        for (int winnerIdx : result.winnerIndexes()) {
+            gameRepository.appendAction(id, new ActionRecord(nextSeq++, winnerIdx,
+                    ActionType.SHOWDOWN, 0, handLabel));
+        }
+        // ペイアウトレコードを記録
+        List<Integer> payouts = result.payouts();
+        for (int i = 0; i < payouts.size(); i++) {
+            if (payouts.get(i) > 0) {
+                gameRepository.appendAction(id, new ActionRecord(nextSeq++, i,
+                        ActionType.PAYOUT, payouts.get(i), null));
+            }
+        }
+
         recordHandHistoryIfFinished(id, state);
         TableService tableService = tableServiceProvider.getIfAvailable();
         if (tableService != null) {

--- a/mapoker-backend/src/main/java/com/mapoker/application/GameService.java
+++ b/mapoker-backend/src/main/java/com/mapoker/application/GameService.java
@@ -259,22 +259,24 @@ public class GameService {
         state.applyPayouts(result.payouts());
         gameRepository.update(id, state);
 
-        // ショーダウン結果をアクションログに永続化
-        int nextSeq = gameRepository.findActionsByGameId(id).size() + 1;
-        boolean isFoldWin = result.bestHand() == null
-                || result.bestHand().rank() == null;
-        String handLabel = isFoldWin ? "fold_win" : result.bestHand().rank().getLabel();
-        // 勝者のシートインデックスを使って SHOWDOWN レコードを記録
-        for (int winnerIdx : result.winnerIndexes()) {
-            gameRepository.appendAction(id, new ActionRecord(nextSeq++, winnerIdx,
-                    ActionType.SHOWDOWN, 0, handLabel));
-        }
-        // ペイアウトレコードを記録
-        List<Integer> payouts = result.payouts();
-        for (int i = 0; i < payouts.size(); i++) {
-            if (payouts.get(i) > 0) {
-                gameRepository.appendAction(id, new ActionRecord(nextSeq++, i,
-                        ActionType.PAYOUT, payouts.get(i), null));
+        // ショーダウン結果をアクションログに永続化（二重呼び出し対策: 既存ならスキップ）
+        List<ActionRecord> existing = gameRepository.findActionsByGameId(id);
+        boolean alreadyRecorded = existing.stream()
+                .anyMatch(a -> a.actionType() == ActionType.SHOWDOWN || a.actionType() == ActionType.PAYOUT);
+        if (!alreadyRecorded) {
+            int nextSeq = existing.size() + 1;
+            boolean isFoldWin = result.bestHand() == null || result.bestHand().rank() == null;
+            String handLabel = isFoldWin ? "fold_win" : result.bestHand().rank().getLabel();
+            for (int winnerIdx : result.winnerIndexes()) {
+                gameRepository.appendAction(id, new ActionRecord(nextSeq++, winnerIdx,
+                        ActionType.SHOWDOWN, 0, handLabel));
+            }
+            List<Integer> payouts = result.payouts();
+            for (int i = 0; i < payouts.size(); i++) {
+                if (payouts.get(i) > 0) {
+                    gameRepository.appendAction(id, new ActionRecord(nextSeq++, i,
+                            ActionType.PAYOUT, payouts.get(i), null));
+                }
             }
         }
 

--- a/mapoker-backend/src/main/java/com/mapoker/application/TableService.java
+++ b/mapoker-backend/src/main/java/com/mapoker/application/TableService.java
@@ -400,11 +400,11 @@ public class TableService {
     }
 
     /**
-     * 24 時間以上無人のテーブルを削除します。Spring Scheduler により 1 時間ごとに実行されます。
+     * 1 時間以上無人のテーブルを削除します。Spring Scheduler により 10 分ごとに実行されます。
      */
-    @Scheduled(fixedDelay = 3_600_000)
+    @Scheduled(fixedDelay = 600_000)
     public void removeStaleEmptyTables() {
-        Instant threshold = Instant.now().minus(24, ChronoUnit.HOURS);
+        Instant threshold = Instant.now().minus(1, ChronoUnit.HOURS);
         lastEmptiedAt.entrySet().removeIf(entry -> {
             if (entry.getValue().isBefore(threshold)) {
                 String tableId = entry.getKey();

--- a/mapoker-backend/src/main/java/com/mapoker/application/TableService.java
+++ b/mapoker-backend/src/main/java/com/mapoker/application/TableService.java
@@ -10,6 +10,8 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import org.springframework.scheduling.annotation.Scheduled;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashSet;
@@ -29,6 +31,8 @@ public class TableService {
     private final Map<String, TableRecord> tables = new ConcurrentHashMap<>();
     private final Map<String, List<TableMemberRecord>> tableMembers = new ConcurrentHashMap<>();
     private final Map<String, Object> tableLocks = new ConcurrentHashMap<>();
+    /** テーブルが最後に空になった日時（メンバーが0人になった瞬間を記録）。 */
+    private final Map<String, java.time.Instant> lastEmptiedAt = new ConcurrentHashMap<>();
 
     private final GameService gameService;
     private final GameProperties gameProperties;
@@ -346,6 +350,7 @@ public class TableService {
             cashOutSeatStackIfPossible(member.name(), table.gameId(), member.seatIndex());
             userTableHistoryService.recordLeave(member.name(), table.id(), member.seatIndex());
             List<TableMemberRecord> result = List.copyOf(members);
+            trackEmptyTable(table.id(), result);
             publishMembers(table.id(), result);
             return result;
         }
@@ -379,8 +384,36 @@ public class TableService {
             }
             remainingMembers.sort(Comparator.comparingInt(TableMemberRecord::seatIndex));
             tableMembers.put(table.id(), remainingMembers);
-            publishMembers(tableId, List.copyOf(remainingMembers));
+            List<TableMemberRecord> remaining = List.copyOf(remainingMembers);
+            trackEmptyTable(tableId, remaining);
+            publishMembers(tableId, remaining);
         }
+    }
+
+    /** メンバーが空になったときに lastEmptiedAt を記録する。 */
+    private void trackEmptyTable(String tableId, List<TableMemberRecord> members) {
+        if (members.isEmpty()) {
+            lastEmptiedAt.putIfAbsent(tableId, Instant.now());
+        } else {
+            lastEmptiedAt.remove(tableId);
+        }
+    }
+
+    /**
+     * 24 時間以上無人のテーブルを削除します。Spring Scheduler により 1 時間ごとに実行されます。
+     */
+    @Scheduled(fixedDelay = 3_600_000)
+    public void removeStaleEmptyTables() {
+        Instant threshold = Instant.now().minus(24, ChronoUnit.HOURS);
+        lastEmptiedAt.entrySet().removeIf(entry -> {
+            if (entry.getValue().isBefore(threshold)) {
+                String tableId = entry.getKey();
+                tables.remove(tableId);
+                tableMembers.remove(tableId);
+                return true;
+            }
+            return false;
+        });
     }
 
     private void publishMembers(String tableId, List<TableMemberRecord> members) {

--- a/mapoker-backend/src/main/java/com/mapoker/application/TableService.java
+++ b/mapoker-backend/src/main/java/com/mapoker/application/TableService.java
@@ -230,8 +230,18 @@ public class TableService {
                     .findFirst()
                     .orElse(null);
             if (existing != null) {
-                // スタックが 0 かつ buyIn > 0 の場合はリバイとして処理
                 int currentStack = gameService.getSeatStack(table.gameId(), existing.seatIndex());
+                GameState state = gameService.getGame(table.gameId());
+                boolean handActive = (state.getStatus() == GameStatus.IN_PROGRESS && state.getPot() > 0)
+                        || state.getStatus() == GameStatus.SHOWDOWN;
+
+                // ハンド非進行中にスタックが残っている（切断・未退席）場合はキャッシュアウトしてから再バイイン
+                if (currentStack > 0 && !handActive) {
+                    cashOutSeatStackIfPossible(name, table.gameId(), existing.seatIndex());
+                    currentStack = 0;
+                }
+
+                // スタックが 0 かつ buyIn > 0 の場合はリバイとして処理
                 if (currentStack == 0 && buyIn > 0) {
                     WalletService walletService = walletServiceProvider.getIfAvailable();
                     if (walletService != null) {

--- a/mapoker-backend/src/main/java/com/mapoker/domain/rules/ActionType.java
+++ b/mapoker-backend/src/main/java/com/mapoker/domain/rules/ActionType.java
@@ -18,7 +18,11 @@ public enum ActionType {
     /** レイズです。 */
     RAISE("raise"),
     /** オールインです。 */
-    ALL_IN("all_in");
+    ALL_IN("all_in"),
+    /** ショーダウン結果です。label に役名を格納します。 */
+    SHOWDOWN("showdown"),
+    /** ポット獲得です。amount に獲得チップ数を格納します。 */
+    PAYOUT("payout");
 
     private final String label;
 

--- a/mapoker-backend/src/main/java/com/mapoker/infrastructure/messaging/WebSocketEventListener.java
+++ b/mapoker-backend/src/main/java/com/mapoker/infrastructure/messaging/WebSocketEventListener.java
@@ -1,0 +1,113 @@
+package com.mapoker.infrastructure.messaging;
+
+import com.mapoker.application.TableService;
+import com.mapoker.application.UserService;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
+
+/**
+ * WebSocket セッションの接続・切断イベントを処理するコンポーネントです。
+ *
+ * <p>切断時は 30 秒の猶予を設けた後、テーブルから自動退席します。
+ * 猶予期間内に再接続（再購読）した場合はキャンセルします。
+ */
+@Component
+public class WebSocketEventListener {
+
+    private static final long DISCONNECT_GRACE_MS = 30_000;
+
+    /** sessionId → [tableId, username] */
+    private final Map<String, String[]> sessionToTable = new ConcurrentHashMap<>();
+    /** sessionId → pending leave task */
+    private final Map<String, ScheduledFuture<?>> pendingLeaves = new ConcurrentHashMap<>();
+
+    private final ObjectProvider<TableService> tableServiceProvider;
+    private final ObjectProvider<UserService> userServiceProvider;
+    private final ThreadPoolTaskScheduler scheduler;
+
+    public WebSocketEventListener(ObjectProvider<TableService> tableServiceProvider,
+                                  ObjectProvider<UserService> userServiceProvider) {
+        this.tableServiceProvider = tableServiceProvider;
+        this.userServiceProvider = userServiceProvider;
+        this.scheduler = new ThreadPoolTaskScheduler();
+        this.scheduler.setPoolSize(2);
+        this.scheduler.setThreadNamePrefix("ws-disconnect-");
+        this.scheduler.initialize();
+    }
+
+    /**
+     * ゲーム topic への購読を検知し、sessionId とテーブル・ユーザー情報を記録します。
+     *
+     * <p>再接続時は保留中の退席タスクをキャンセルします。
+     */
+    @EventListener
+    public void handleSubscribe(SessionSubscribeEvent event) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+        String destination = accessor.getDestination();
+        String sessionId = accessor.getSessionId();
+        if (destination == null || sessionId == null) return;
+
+        // /topic/tables/{tableId}/game
+        if (!destination.matches("/topic/tables/[^/]+/game")) return;
+
+        String[] parts = destination.split("/");
+        if (parts.length < 5) return;
+        String tableId = parts[3];
+
+        String principalName = event.getUser() != null ? event.getUser().getName() : null;
+        if (principalName == null) return;
+
+        UserService userService = userServiceProvider.getIfAvailable();
+        if (userService == null) return;
+        String username;
+        try {
+            username = userService.getByPublicId(principalName).username();
+        } catch (Exception e) {
+            return;
+        }
+
+        sessionToTable.put(sessionId, new String[]{ tableId, username });
+
+        // 再接続: 保留中の退席をキャンセル
+        ScheduledFuture<?> pending = pendingLeaves.remove(sessionId);
+        if (pending != null) pending.cancel(false);
+    }
+
+    /**
+     * WebSocket 切断を検知し、{@value DISCONNECT_GRACE_MS}ms 後に自動退席を実行します。
+     */
+    @EventListener
+    public void handleDisconnect(SessionDisconnectEvent event) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+        String sessionId = accessor.getSessionId();
+        if (sessionId == null) return;
+
+        String[] info = sessionToTable.get(sessionId);
+        if (info == null) return;
+
+        String tableId = info[0];
+        String username = info[1];
+
+        ScheduledFuture<?> task = scheduler.schedule(() -> {
+            sessionToTable.remove(sessionId);
+            pendingLeaves.remove(sessionId);
+            TableService tableService = tableServiceProvider.getIfAvailable();
+            if (tableService == null) return;
+            try {
+                tableService.leave(tableId, username, null);
+            } catch (Exception ignored) {}
+        }, Instant.now().plusMillis(DISCONNECT_GRACE_MS));
+
+        pendingLeaves.put(sessionId, task);
+    }
+}

--- a/mapoker-backend/src/main/java/com/mapoker/infrastructure/persistence/InMemoryGameRepository.java
+++ b/mapoker-backend/src/main/java/com/mapoker/infrastructure/persistence/InMemoryGameRepository.java
@@ -89,6 +89,11 @@ public class InMemoryGameRepository implements GameRepository {
      * @return アクション履歴一覧
      */
     @Override
+    public void appendAction(String id, ActionRecord action) {
+        actions.computeIfAbsent(id, k -> new ArrayList<>()).add(action);
+    }
+
+    @Override
     public List<ActionRecord> findActionsByGameId(String gameId) {
         return actions.getOrDefault(gameId, List.of());
     }

--- a/mapoker-backend/src/main/java/com/mapoker/infrastructure/persistence/PostgresGameRepository.java
+++ b/mapoker-backend/src/main/java/com/mapoker/infrastructure/persistence/PostgresGameRepository.java
@@ -143,7 +143,8 @@ public class PostgresGameRepository implements GameRepository {
                         rs.getInt("seq"),
                         rs.getInt("player_index"),
                         ActionType.fromLabel(rs.getString("action_type")),
-                        rs.getInt("amount")),
+                        rs.getInt("amount"),
+                        rs.getString("label")),
                 gameId);
     }
 
@@ -263,13 +264,18 @@ public class PostgresGameRepository implements GameRepository {
         }
     }
 
+    @Override
+    public void appendAction(String id, ActionRecord action) {
+        insertAction(id, action);
+    }
+
     private void insertAction(String id, ActionRecord action) {
         jdbc.update("""
-                INSERT INTO actions (game_id, seq, player_index, action_type, amount)
-                VALUES (?, ?, ?, CAST(? AS action_type), ?)
+                INSERT INTO actions (game_id, seq, player_index, action_type, amount, label)
+                VALUES (?, ?, ?, CAST(? AS action_type), ?, ?)
                 """,
                 id, action.seq(), action.playerIndex(),
-                action.actionType().getLabel(), action.amount());
+                action.actionType().getLabel(), action.amount(), action.label());
     }
 
     // ---- deserialize ----

--- a/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/ActionsResponse.java
+++ b/mapoker-backend/src/main/java/com/mapoker/interfaces/http/dto/ActionsResponse.java
@@ -1,5 +1,6 @@
 package com.mapoker.interfaces.http.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mapoker.application.ActionRecord;
 import com.mapoker.domain.rules.ActionType;
@@ -15,16 +16,18 @@ public record ActionsResponse(List<ActionDto> actions) {
     /**
      * 単一アクションの表示 DTO です。
      *
-     * @param seq 連番
+     * @param seq         連番
      * @param playerIndex プレイヤー位置
-     * @param type 行動種別
-     * @param amount 金額
+     * @param type        行動種別
+     * @param amount      金額
+     * @param label       補足ラベル（ショーダウン時の役名など、null 可）
      */
     public record ActionDto(
             int seq,
             @JsonProperty("player_index") int playerIndex,
             ActionType type,
-            int amount
+            int amount,
+            @JsonInclude(JsonInclude.Include.NON_NULL) String label
     ) {}
 
     /**
@@ -35,7 +38,7 @@ public record ActionsResponse(List<ActionDto> actions) {
      */
     public static ActionsResponse from(List<ActionRecord> records) {
         List<ActionDto> dtos = records.stream()
-                .map(r -> new ActionDto(r.seq(), r.playerIndex(), r.actionType(), r.amount()))
+                .map(r -> new ActionDto(r.seq(), r.playerIndex(), r.actionType(), r.amount(), r.label()))
                 .toList();
         return new ActionsResponse(dtos);
     }

--- a/mapoker-backend/src/main/resources/db/migration/V11__add_label_to_actions.sql
+++ b/mapoker-backend/src/main/resources/db/migration/V11__add_label_to_actions.sql
@@ -1,0 +1,6 @@
+-- アクションテーブルに補足ラベルカラムを追加（ショーダウン役名など）
+ALTER TABLE actions ADD COLUMN IF NOT EXISTS label VARCHAR(100);
+
+-- action_type enum に showdown / payout を追加
+ALTER TYPE action_type ADD VALUE IF NOT EXISTS 'showdown';
+ALTER TYPE action_type ADD VALUE IF NOT EXISTS 'payout';

--- a/mapoker-frontend/src/App.css
+++ b/mapoker-frontend/src/App.css
@@ -838,10 +838,24 @@ button.icon-btn[data-label]:hover::after {
   min-width: 2rem;
 }
 
+.action-log-divider {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--text-muted);
+  text-align: center;
+  padding: 0.4rem 1rem;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  background: var(--surface-2);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
 .action-log-fold    { color: #e57373; }
 .action-log-all_in  { color: var(--poker-gold); }
 .action-log-bet,
 .action-log-raise   { color: var(--accent); }
+.action-log-payout  { color: var(--poker-gold); font-weight: 600; }
 
 .leave-area {
   position: fixed;

--- a/mapoker-frontend/src/App.css
+++ b/mapoker-frontend/src/App.css
@@ -580,6 +580,25 @@
   min-width: 140px;
 }
 
+.bet-step-btn {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 1.5px solid var(--border);
+  background: var(--surface-3);
+  color: var(--text-base);
+  font-size: 1rem;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 0.15s;
+}
+.bet-step-btn:hover:not(:disabled) { background: var(--surface-2); }
+.bet-step-btn:disabled { opacity: 0.35; cursor: not-allowed; }
+
 .bet-slider {
   flex: 1;
   height: 4px;
@@ -763,6 +782,37 @@ button.icon-btn[data-label]:hover::after {
 }
 
 /* ---- 退席エリア (右下固定) ---- */
+.action-log {
+  position: fixed;
+  bottom: 5rem;
+  left: 0.75rem;
+  width: 220px;
+  max-height: 160px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  pointer-events: none;
+  z-index: 20;
+}
+
+.action-log-entry {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  background: rgba(0, 0, 0, 0.55);
+  border-radius: 4px;
+  padding: 0.15rem 0.4rem;
+  backdrop-filter: blur(4px);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.action-log-fold    { color: #e57373; }
+.action-log-all_in  { color: var(--poker-gold); }
+.action-log-bet,
+.action-log-raise   { color: var(--accent); }
+
 .leave-area {
   position: fixed;
   bottom: 1.25rem;

--- a/mapoker-frontend/src/App.css
+++ b/mapoker-frontend/src/App.css
@@ -783,26 +783,20 @@ button.icon-btn[data-label]:hover::after {
 
 /* ---- 退席エリア (右下固定) ---- */
 .action-log {
-  position: fixed;
-  bottom: 5rem;
-  left: 0.75rem;
-  width: 220px;
-  max-height: 160px;
+  flex-shrink: 0;
+  max-height: 80px;
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: 0.2rem;
-  pointer-events: none;
-  z-index: 20;
+  gap: 0.15rem;
+  padding: 0.3rem 1.25rem;
+  background: rgba(8, 12, 20, 0.75);
+  border-top: 1px solid rgba(255,255,255,0.04);
 }
 
 .action-log-entry {
   font-size: 0.72rem;
   color: var(--text-muted);
-  background: rgba(0, 0, 0, 0.55);
-  border-radius: 4px;
-  padding: 0.15rem 0.4rem;
-  backdrop-filter: blur(4px);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/mapoker-frontend/src/App.css
+++ b/mapoker-frontend/src/App.css
@@ -838,24 +838,12 @@ button.icon-btn[data-label]:hover::after {
   min-width: 2rem;
 }
 
-.action-log-divider {
-  font-size: 0.75rem;
-  font-weight: 700;
-  color: var(--text-muted);
-  text-align: center;
-  padding: 0.4rem 1rem;
-  border-top: 1px solid var(--border);
-  border-bottom: 1px solid var(--border);
-  background: var(--surface-2);
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-}
-
-.action-log-fold    { color: #e57373; }
-.action-log-all_in  { color: var(--poker-gold); }
+.action-log-fold     { color: #e57373; }
+.action-log-all_in   { color: var(--poker-gold); }
 .action-log-bet,
-.action-log-raise   { color: var(--accent); }
-.action-log-payout  { color: var(--poker-gold); font-weight: 600; }
+.action-log-raise    { color: var(--accent); }
+.action-log-showdown { color: #ce93d8; font-weight: 600; }
+.action-log-payout   { color: var(--poker-gold); font-weight: 600; }
 
 .leave-area {
   position: fixed;

--- a/mapoker-frontend/src/App.css
+++ b/mapoker-frontend/src/App.css
@@ -784,12 +784,11 @@ button.icon-btn[data-label]:hover::after {
 /* ---- 退席エリア (右下固定) ---- */
 .action-log {
   flex-shrink: 0;
-  max-height: 80px;
-  overflow-y: auto;
+  overflow: hidden;
   display: flex;
   flex-direction: column;
   gap: 0.15rem;
-  padding: 0.3rem 1.25rem;
+  padding: 0.25rem 1.25rem;
   background: rgba(8, 12, 20, 0.75);
   border-top: 1px solid rgba(255,255,255,0.04);
 }

--- a/mapoker-frontend/src/App.css
+++ b/mapoker-frontend/src/App.css
@@ -782,23 +782,60 @@ button.icon-btn[data-label]:hover::after {
 }
 
 /* ---- 退席エリア (右下固定) ---- */
-.action-log {
-  flex-shrink: 0;
-  overflow: hidden;
+/* ── アクションログ ダイアログ ── */
+.action-log-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+}
+
+.action-log-dialog {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  width: min(420px, 92vw);
+  max-height: 70vh;
   display: flex;
   flex-direction: column;
-  gap: 0.15rem;
-  padding: 0.25rem 1.25rem;
-  background: rgba(8, 12, 20, 0.75);
-  border-top: 1px solid rgba(255,255,255,0.04);
+  box-shadow: var(--shadow-lg);
+  overflow: hidden;
+}
+
+.action-log-dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border);
+  font-weight: 700;
+  font-size: 0.9rem;
+}
+
+.action-log-dialog-body {
+  overflow-y: auto;
+  padding: 0.5rem 0;
+  flex: 1;
 }
 
 .action-log-entry {
-  font-size: 0.72rem;
+  font-size: 0.82rem;
   color: var(--text-muted);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  padding: 0.3rem 1rem;
+  display: flex;
+  gap: 0.5rem;
+}
+.action-log-entry:nth-child(odd) { background: rgba(255,255,255,0.02); }
+
+.action-log-seq {
+  color: var(--text-muted);
+  opacity: 0.5;
+  font-size: 0.75rem;
+  flex-shrink: 0;
+  min-width: 2rem;
 }
 
 .action-log-fold    { color: #e57373; }

--- a/mapoker-frontend/src/App.tsx
+++ b/mapoker-frontend/src/App.tsx
@@ -469,6 +469,17 @@ function App() {
   }
 
   const handleLogout = async () => {
+    // テーブルに着席中ならログアウト前にキャッシュアウト退席する
+    if (gameId && myName.trim()) {
+      try {
+        await fetchJSON(`/v1/tables/${gameId}/leave`, {
+          method: 'POST',
+          body: JSON.stringify({ name: myName.trim(), seat_index: mySeatIndex }),
+        })
+      } catch {
+        // ignore — サーバー側で未処理のまま logout を続行
+      }
+    }
     try {
       await fetchJSON('/v1/auth/logout', { method: 'POST' })
     } catch {

--- a/mapoker-frontend/src/components/GameScreen/ActionLog.tsx
+++ b/mapoker-frontend/src/components/GameScreen/ActionLog.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { fetchJSON } from '../../api'
-import type { ActionLogEntry, GameState } from '../../types'
+import type { ActionLogEntry, GameState, PayoutLine, Showdown } from '../../types'
 
 const ACTION_LABELS: Record<string, string> = {
   FOLD: 'フォールド',
@@ -13,12 +13,19 @@ const ACTION_LABELS: Record<string, string> = {
 
 type Props = {
   game: GameState
+  showdown: Showdown | null
+  payoutLines: PayoutLine[]
   displayName: (idx: number) => string
   open: boolean
   onClose: () => void
 }
 
-export function ActionLogDialog({ game, displayName, open, onClose }: Props) {
+type LogItem =
+  | { kind: 'action'; entry: ActionLogEntry }
+  | { kind: 'divider'; label: string }
+  | { kind: 'payout'; name: string; amount: number }
+
+export function ActionLogDialog({ game, showdown, payoutLines, displayName, open, onClose }: Props) {
   const [entries, setEntries] = useState<ActionLogEntry[]>([])
   const bottomRef = useRef<HTMLDivElement>(null)
 
@@ -31,18 +38,31 @@ export function ActionLogDialog({ game, displayName, open, onClose }: Props) {
 
   useEffect(() => {
     if (open) bottomRef.current?.scrollIntoView({ behavior: 'instant' })
-  }, [open, entries])
+  }, [open, entries, showdown])
 
   if (!open) return null
 
-  const fmt = (entry: ActionLogEntry) => {
+  const bb = game.big_blind
+  const fmt = (chips: number) =>
+    `¥${chips}${bb > 0 ? ` (${Math.round((chips / bb) * 10) / 10}BB)` : ''}`
+
+  const fmtAction = (entry: ActionLogEntry) => {
     const name = displayName(entry.player_index)
     const label = ACTION_LABELS[entry.type] ?? entry.type.toLowerCase()
-    const bb = game.big_blind
-    const amtStr = entry.amount > 0
-      ? ` ¥${entry.amount}${bb > 0 ? ` (${Math.round((entry.amount / bb) * 10) / 10}BB)` : ''}`
-      : ''
+    const amtStr = entry.amount > 0 ? ` ${fmt(entry.amount)}` : ''
     return `${name} が${label}${amtStr}`
+  }
+
+  // ログアイテムを構築: アクション履歴 + ショーダウン結果
+  const items: LogItem[] = entries.map((e) => ({ kind: 'action', entry: e }))
+
+  const isFinished = game.status === 'finished' || game.status === 'showdown'
+  if (isFinished && payoutLines.length > 0) {
+    const label = game.status === 'finished' && showdown == null ? 'フォールド勝ち' : 'ショーダウン'
+    items.push({ kind: 'divider', label })
+    for (const p of payoutLines) {
+      items.push({ kind: 'payout', name: p.name, amount: p.amount })
+    }
   }
 
   return (
@@ -53,14 +73,31 @@ export function ActionLogDialog({ game, displayName, open, onClose }: Props) {
           <button className="ghost" onClick={onClose}>✕</button>
         </div>
         <div className="action-log-dialog-body">
-          {entries.length === 0
+          {items.length === 0
             ? <div className="muted" style={{ padding: '1rem', textAlign: 'center' }}>まだアクションはありません</div>
-            : entries.map((e) => (
-              <div key={e.seq} className={`action-log-entry action-log-${e.type.toLowerCase()}`}>
-                <span className="action-log-seq">#{e.seq}</span>
-                {fmt(e)}
-              </div>
-            ))
+            : items.map((item, i) => {
+                if (item.kind === 'divider') {
+                  return (
+                    <div key={`divider-${i}`} className="action-log-divider">
+                      {item.label}
+                    </div>
+                  )
+                }
+                if (item.kind === 'payout') {
+                  return (
+                    <div key={`payout-${i}`} className="action-log-entry action-log-payout">
+                      <span className="action-log-seq">💰</span>
+                      {`${item.name} が ${fmt(item.amount)} を獲得`}
+                    </div>
+                  )
+                }
+                return (
+                  <div key={item.entry.seq} className={`action-log-entry action-log-${item.entry.type.toLowerCase()}`}>
+                    <span className="action-log-seq">#{item.entry.seq}</span>
+                    {fmtAction(item.entry)}
+                  </div>
+                )
+              })
           }
           <div ref={bottomRef} />
         </div>

--- a/mapoker-frontend/src/components/GameScreen/ActionLog.tsx
+++ b/mapoker-frontend/src/components/GameScreen/ActionLog.tsx
@@ -2,8 +2,6 @@ import { useEffect, useRef, useState } from 'react'
 import { fetchJSON } from '../../api'
 import type { ActionLogEntry, GameState } from '../../types'
 
-const MAX_LOG = 4
-
 const ACTION_LABELS: Record<string, string> = {
   FOLD: 'フォールド',
   CHECK: 'チェック',
@@ -16,24 +14,26 @@ const ACTION_LABELS: Record<string, string> = {
 type Props = {
   game: GameState
   displayName: (idx: number) => string
+  open: boolean
+  onClose: () => void
 }
 
-export function ActionLog({ game, displayName }: Props) {
+export function ActionLogDialog({ game, displayName, open, onClose }: Props) {
   const [entries, setEntries] = useState<ActionLogEntry[]>([])
   const bottomRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
-    if (!game.id || game.status === 'finished' && game.pot_total === 0) return
+    if (!game.id) return
     fetchJSON<{ actions: ActionLogEntry[] }>(`/v1/games/${game.id}/actions`)
-      .then(({ actions }) => setEntries(actions.slice(-MAX_LOG)))
+      .then(({ actions }) => setEntries(actions))
       .catch(() => {})
   }, [game.id, game.current_player, game.street, game.status])
 
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
-  }, [entries])
+    if (open) bottomRef.current?.scrollIntoView({ behavior: 'instant' })
+  }, [open, entries])
 
-  if (entries.length === 0) return null
+  if (!open) return null
 
   const fmt = (entry: ActionLogEntry) => {
     const name = displayName(entry.player_index)
@@ -46,13 +46,25 @@ export function ActionLog({ game, displayName }: Props) {
   }
 
   return (
-    <div className="action-log">
-      {entries.map((e) => (
-        <div key={e.seq} className={`action-log-entry action-log-${e.type.toLowerCase()}`}>
-          {fmt(e)}
+    <div className="action-log-overlay" onClick={onClose} role="presentation">
+      <div className="action-log-dialog" onClick={(e) => e.stopPropagation()}>
+        <div className="action-log-dialog-header">
+          <span>アクションログ</span>
+          <button className="ghost" onClick={onClose}>✕</button>
         </div>
-      ))}
-      <div ref={bottomRef} />
+        <div className="action-log-dialog-body">
+          {entries.length === 0
+            ? <div className="muted" style={{ padding: '1rem', textAlign: 'center' }}>まだアクションはありません</div>
+            : entries.map((e) => (
+              <div key={e.seq} className={`action-log-entry action-log-${e.type.toLowerCase()}`}>
+                <span className="action-log-seq">#{e.seq}</span>
+                {fmt(e)}
+              </div>
+            ))
+          }
+          <div ref={bottomRef} />
+        </div>
+      </div>
     </div>
   )
 }

--- a/mapoker-frontend/src/components/GameScreen/ActionLog.tsx
+++ b/mapoker-frontend/src/components/GameScreen/ActionLog.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { fetchJSON } from '../../api'
 import type { ActionLogEntry, GameState, PayoutLine, Showdown } from '../../types'
+import { hasTranslation, t } from '../../i18n'
 
 const ACTION_LABELS: Record<string, string> = {
   FOLD: 'フォールド',
@@ -58,7 +59,15 @@ export function ActionLogDialog({ game, showdown, payoutLines, displayName, open
 
   const isFinished = game.status === 'finished' || game.status === 'showdown'
   if (isFinished && payoutLines.length > 0) {
-    const label = game.status === 'finished' && showdown == null ? 'フォールド勝ち' : 'ショーダウン'
+    const isFoldWin = game.status === 'finished' && showdown == null
+    // ショーダウン divider: 勝者名 + 役を表示
+    let label = 'フォールド勝ち'
+    if (!isFoldWin && showdown) {
+      const winnerNames = (showdown.winners ?? []).map((i) => displayName(i)).join(', ')
+      const rank = showdown.best_hand?.rank
+      const rankLabel = rank && hasTranslation(rank) ? t(rank as Parameters<typeof t>[0]) : rank ?? ''
+      label = rankLabel ? `${winnerNames} — ${rankLabel}` : `${winnerNames} 勝利`
+    }
     items.push({ kind: 'divider', label })
     for (const p of payoutLines) {
       items.push({ kind: 'payout', name: p.name, amount: p.amount })

--- a/mapoker-frontend/src/components/GameScreen/ActionLog.tsx
+++ b/mapoker-frontend/src/components/GameScreen/ActionLog.tsx
@@ -1,32 +1,27 @@
 import { useEffect, useRef, useState } from 'react'
 import { fetchJSON } from '../../api'
-import type { ActionLogEntry, GameState, PayoutLine, Showdown } from '../../types'
+import type { ActionLogEntry, GameState } from '../../types'
 import { hasTranslation, t } from '../../i18n'
 
 const ACTION_LABELS: Record<string, string> = {
-  FOLD: 'フォールド',
-  CHECK: 'チェック',
-  CALL: 'コール',
-  BET: 'ベット',
-  RAISE: 'レイズ',
-  ALL_IN: 'オールイン',
+  fold: 'フォールド',
+  check: 'チェック',
+  call: 'コール',
+  bet: 'ベット',
+  raise: 'レイズ',
+  all_in: 'オールイン',
+  showdown: 'ショーダウン',
+  payout: 'ポット獲得',
 }
 
 type Props = {
   game: GameState
-  showdown: Showdown | null
-  payoutLines: PayoutLine[]
   displayName: (idx: number) => string
   open: boolean
   onClose: () => void
 }
 
-type LogItem =
-  | { kind: 'action'; entry: ActionLogEntry }
-  | { kind: 'showdown'; label: string }
-  | { kind: 'payout'; name: string; amount: number }
-
-export function ActionLogDialog({ game, showdown, payoutLines, displayName, open, onClose }: Props) {
+export function ActionLogDialog({ game, displayName, open, onClose }: Props) {
   const [entries, setEntries] = useState<ActionLogEntry[]>([])
   const bottomRef = useRef<HTMLDivElement>(null)
 
@@ -35,11 +30,11 @@ export function ActionLogDialog({ game, showdown, payoutLines, displayName, open
     fetchJSON<{ actions: ActionLogEntry[] }>(`/v1/games/${game.id}/actions`)
       .then(({ actions }) => setEntries(actions))
       .catch(() => {})
-  }, [game.id, game.current_player, game.street, game.status, showdown])
+  }, [game.id, game.current_player, game.street, game.status])
 
   useEffect(() => {
     if (open) bottomRef.current?.scrollIntoView({ behavior: 'instant' })
-  }, [open, entries, showdown])
+  }, [open, entries])
 
   if (!open) return null
 
@@ -47,30 +42,22 @@ export function ActionLogDialog({ game, showdown, payoutLines, displayName, open
   const fmt = (chips: number) =>
     `¥${chips}${bb > 0 ? ` (${Math.round((chips / bb) * 10) / 10}BB)` : ''}`
 
-  const items: LogItem[] = entries.map((e) => ({ kind: 'action', entry: e }))
+  const renderEntry = (e: ActionLogEntry) => {
+    const name = displayName(e.player_index)
+    const type = e.type.toLowerCase()
 
-  // showdown 結果はハンド終了後かつ解決済みのときのみ追加（ネタバレ防止）
-  const resolved = game.status === 'finished' && showdown !== null
-  if (resolved && payoutLines.length > 0) {
-    const isFoldWin = showdown.best_hand == null
-    if (isFoldWin) {
-      items.push({ kind: 'showdown', label: 'フォールド勝ち' })
-    } else {
-      const winnerNames = (showdown.winners ?? []).map((i) => displayName(i)).join(', ')
-      const rank = showdown.best_hand?.rank
+    if (type === 'showdown') {
+      const rank = e.label
       const rankLabel = rank && hasTranslation(rank) ? t(rank as Parameters<typeof t>[0]) : (rank ?? '')
-      items.push({ kind: 'showdown', label: `${winnerNames} — ${rankLabel}` })
+      return { text: `${name} — ${rankLabel}`, cls: 'action-log-showdown', icon: '🃏' }
     }
-    for (const p of payoutLines) {
-      items.push({ kind: 'payout', name: p.name, amount: p.amount })
+    if (type === 'payout') {
+      return { text: `${name} が ${fmt(e.amount)} を獲得`, cls: 'action-log-payout', icon: '💰' }
     }
-  }
 
-  const fmtAction = (entry: ActionLogEntry) => {
-    const name = displayName(entry.player_index)
-    const label = ACTION_LABELS[entry.type] ?? entry.type.toLowerCase()
-    const amtStr = entry.amount > 0 ? ` ${fmt(entry.amount)}` : ''
-    return `${name} が${label}${amtStr}`
+    const label = ACTION_LABELS[type] ?? type
+    const amtStr = e.amount > 0 ? ` ${fmt(e.amount)}` : ''
+    return { text: `${name} が${label}${amtStr}`, cls: `action-log-${type}`, icon: `#${e.seq}` }
   }
 
   return (
@@ -81,29 +68,14 @@ export function ActionLogDialog({ game, showdown, payoutLines, displayName, open
           <button className="ghost" onClick={onClose}>✕</button>
         </div>
         <div className="action-log-dialog-body">
-          {items.length === 0
+          {entries.length === 0
             ? <div className="muted" style={{ padding: '1rem', textAlign: 'center' }}>まだアクションはありません</div>
-            : items.map((item, i) => {
-                if (item.kind === 'showdown') {
-                  return (
-                    <div key={`sd-${i}`} className="action-log-entry action-log-showdown">
-                      <span className="action-log-seq">🃏</span>
-                      {item.label}
-                    </div>
-                  )
-                }
-                if (item.kind === 'payout') {
-                  return (
-                    <div key={`pay-${i}`} className="action-log-entry action-log-payout">
-                      <span className="action-log-seq">💰</span>
-                      {`${item.name} が ${fmt(item.amount)} を獲得`}
-                    </div>
-                  )
-                }
+            : entries.map((e, i) => {
+                const { text, cls, icon } = renderEntry(e)
                 return (
-                  <div key={item.entry.seq} className={`action-log-entry action-log-${item.entry.type.toLowerCase()}`}>
-                    <span className="action-log-seq">#{item.entry.seq}</span>
-                    {fmtAction(item.entry)}
+                  <div key={i} className={`action-log-entry ${cls}`}>
+                    <span className="action-log-seq">{icon}</span>
+                    {text}
                   </div>
                 )
               })

--- a/mapoker-frontend/src/components/GameScreen/ActionLog.tsx
+++ b/mapoker-frontend/src/components/GameScreen/ActionLog.tsx
@@ -23,7 +23,7 @@ type Props = {
 
 type LogItem =
   | { kind: 'action'; entry: ActionLogEntry }
-  | { kind: 'divider'; label: string }
+  | { kind: 'showdown'; label: string }
   | { kind: 'payout'; name: string; amount: number }
 
 export function ActionLogDialog({ game, showdown, payoutLines, displayName, open, onClose }: Props) {
@@ -35,7 +35,7 @@ export function ActionLogDialog({ game, showdown, payoutLines, displayName, open
     fetchJSON<{ actions: ActionLogEntry[] }>(`/v1/games/${game.id}/actions`)
       .then(({ actions }) => setEntries(actions))
       .catch(() => {})
-  }, [game.id, game.current_player, game.street, game.status])
+  }, [game.id, game.current_player, game.street, game.status, showdown])
 
   useEffect(() => {
     if (open) bottomRef.current?.scrollIntoView({ behavior: 'instant' })
@@ -47,31 +47,30 @@ export function ActionLogDialog({ game, showdown, payoutLines, displayName, open
   const fmt = (chips: number) =>
     `¥${chips}${bb > 0 ? ` (${Math.round((chips / bb) * 10) / 10}BB)` : ''}`
 
+  const items: LogItem[] = entries.map((e) => ({ kind: 'action', entry: e }))
+
+  // showdown 結果はハンド終了後かつ解決済みのときのみ追加（ネタバレ防止）
+  const resolved = game.status === 'finished' && showdown !== null
+  if (resolved && payoutLines.length > 0) {
+    const isFoldWin = showdown.best_hand == null
+    if (isFoldWin) {
+      items.push({ kind: 'showdown', label: 'フォールド勝ち' })
+    } else {
+      const winnerNames = (showdown.winners ?? []).map((i) => displayName(i)).join(', ')
+      const rank = showdown.best_hand?.rank
+      const rankLabel = rank && hasTranslation(rank) ? t(rank as Parameters<typeof t>[0]) : (rank ?? '')
+      items.push({ kind: 'showdown', label: `${winnerNames} — ${rankLabel}` })
+    }
+    for (const p of payoutLines) {
+      items.push({ kind: 'payout', name: p.name, amount: p.amount })
+    }
+  }
+
   const fmtAction = (entry: ActionLogEntry) => {
     const name = displayName(entry.player_index)
     const label = ACTION_LABELS[entry.type] ?? entry.type.toLowerCase()
     const amtStr = entry.amount > 0 ? ` ${fmt(entry.amount)}` : ''
     return `${name} が${label}${amtStr}`
-  }
-
-  // ログアイテムを構築: アクション履歴 + ショーダウン結果
-  const items: LogItem[] = entries.map((e) => ({ kind: 'action', entry: e }))
-
-  const isFinished = game.status === 'finished' || game.status === 'showdown'
-  if (isFinished && payoutLines.length > 0) {
-    const isFoldWin = game.status === 'finished' && showdown == null
-    // ショーダウン divider: 勝者名 + 役を表示
-    let label = 'フォールド勝ち'
-    if (!isFoldWin && showdown) {
-      const winnerNames = (showdown.winners ?? []).map((i) => displayName(i)).join(', ')
-      const rank = showdown.best_hand?.rank
-      const rankLabel = rank && hasTranslation(rank) ? t(rank as Parameters<typeof t>[0]) : rank ?? ''
-      label = rankLabel ? `${winnerNames} — ${rankLabel}` : `${winnerNames} 勝利`
-    }
-    items.push({ kind: 'divider', label })
-    for (const p of payoutLines) {
-      items.push({ kind: 'payout', name: p.name, amount: p.amount })
-    }
   }
 
   return (
@@ -85,16 +84,17 @@ export function ActionLogDialog({ game, showdown, payoutLines, displayName, open
           {items.length === 0
             ? <div className="muted" style={{ padding: '1rem', textAlign: 'center' }}>まだアクションはありません</div>
             : items.map((item, i) => {
-                if (item.kind === 'divider') {
+                if (item.kind === 'showdown') {
                   return (
-                    <div key={`divider-${i}`} className="action-log-divider">
+                    <div key={`sd-${i}`} className="action-log-entry action-log-showdown">
+                      <span className="action-log-seq">🃏</span>
                       {item.label}
                     </div>
                   )
                 }
                 if (item.kind === 'payout') {
                   return (
-                    <div key={`payout-${i}`} className="action-log-entry action-log-payout">
+                    <div key={`pay-${i}`} className="action-log-entry action-log-payout">
                       <span className="action-log-seq">💰</span>
                       {`${item.name} が ${fmt(item.amount)} を獲得`}
                     </div>

--- a/mapoker-frontend/src/components/GameScreen/ActionLog.tsx
+++ b/mapoker-frontend/src/components/GameScreen/ActionLog.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useRef, useState } from 'react'
+import { fetchJSON } from '../../api'
+import type { ActionLogEntry, GameState } from '../../types'
+
+const MAX_LOG = 10
+
+const ACTION_LABELS: Record<string, string> = {
+  FOLD: 'フォールド',
+  CHECK: 'チェック',
+  CALL: 'コール',
+  BET: 'ベット',
+  RAISE: 'レイズ',
+  ALL_IN: 'オールイン',
+}
+
+type Props = {
+  game: GameState
+  displayName: (idx: number) => string
+}
+
+export function ActionLog({ game, displayName }: Props) {
+  const [entries, setEntries] = useState<ActionLogEntry[]>([])
+  const bottomRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!game.id || game.status === 'finished' && game.pot_total === 0) return
+    fetchJSON<{ actions: ActionLogEntry[] }>(`/v1/games/${game.id}/actions`)
+      .then(({ actions }) => setEntries(actions.slice(-MAX_LOG)))
+      .catch(() => {})
+  }, [game.id, game.current_player, game.street, game.status])
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [entries])
+
+  if (entries.length === 0) return null
+
+  const fmt = (entry: ActionLogEntry) => {
+    const name = displayName(entry.player_index)
+    const label = ACTION_LABELS[entry.type] ?? entry.type.toLowerCase()
+    const bb = game.big_blind
+    const amtStr = entry.amount > 0
+      ? ` ¥${entry.amount}${bb > 0 ? ` (${Math.round((entry.amount / bb) * 10) / 10}BB)` : ''}`
+      : ''
+    return `${name} が${label}${amtStr}`
+  }
+
+  return (
+    <div className="action-log">
+      {entries.map((e) => (
+        <div key={e.seq} className={`action-log-entry action-log-${e.type.toLowerCase()}`}>
+          {fmt(e)}
+        </div>
+      ))}
+      <div ref={bottomRef} />
+    </div>
+  )
+}

--- a/mapoker-frontend/src/components/GameScreen/ActionLog.tsx
+++ b/mapoker-frontend/src/components/GameScreen/ActionLog.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { fetchJSON } from '../../api'
 import type { ActionLogEntry, GameState } from '../../types'
 
-const MAX_LOG = 10
+const MAX_LOG = 4
 
 const ACTION_LABELS: Record<string, string> = {
   FOLD: 'フォールド',

--- a/mapoker-frontend/src/components/GameScreen/ActionPanel.tsx
+++ b/mapoker-frontend/src/components/GameScreen/ActionPanel.tsx
@@ -32,6 +32,14 @@ export function ActionPanel({
     }
     return `¥${chips}`
   }
+
+  const canCheck = toCall === 0
+  const step = bb > 0 ? bb : 1
+  const adjustAmount = (delta: number) => {
+    const next = actionAmount + delta * step
+    setActionAmount(Math.min(Math.max(minRaise, next), maxBet))
+  }
+
   return (
     <div className={`action-panel ${canAct ? 'active' : 'inactive'}`}>
       <div className="action-panel-controls">
@@ -69,6 +77,12 @@ export function ActionPanel({
             ))}
           </div>
           <div className="bet-slider-wrap">
+            <button
+              className="bet-step-btn"
+              onClick={() => adjustAmount(-1)}
+              disabled={actionAmount <= minRaise}
+              aria-label="-1BB"
+            >−</button>
             <input
               type="range"
               className="bet-slider"
@@ -77,6 +91,12 @@ export function ActionPanel({
               value={actionAmount}
               onChange={(e) => setActionAmount(Number(e.target.value))}
             />
+            <button
+              className="bet-step-btn"
+              onClick={() => adjustAmount(1)}
+              disabled={actionAmount >= maxBet}
+              aria-label="+1BB"
+            >＋</button>
             <span className="bet-slider-value">{fmt(actionAmount)}</span>
           </div>
         </div>
@@ -87,16 +107,17 @@ export function ActionPanel({
           <button
             className="fold-btn"
             onClick={() => onSendAction('fold', 0)}
-            disabled={!canAct || loading}
+            disabled={!canAct || loading || canCheck}
+            title={canCheck ? 'チェックできます' : undefined}
           >
             {t('fold')}
           </button>
           <button
             className="call-btn"
-            onClick={() => onSendAction(toCall === 0 ? 'check' : 'call', 0)}
+            onClick={() => onSendAction(canCheck ? 'check' : 'call', 0)}
             disabled={!canAct || loading}
           >
-            {toCall === 0 ? t('check') : `${t('call')} ${fmt(toCall)}`}
+            {canCheck ? t('check') : `${t('call')} ${fmt(toCall)}`}
           </button>
           <button
             className="raise-btn"

--- a/mapoker-frontend/src/components/GameScreen/TableArea.tsx
+++ b/mapoker-frontend/src/components/GameScreen/TableArea.tsx
@@ -171,11 +171,13 @@ export function TableArea({
   // setSdStep は setTimeout 経由で呼ぶ（react-hooks/set-state-in-effect 対策）
   useEffect(() => {
     if (!isShowdown) return
+    const RESULT_DELAY = 1500 // カードアニメーション完了後にresultを表示するまでの待機時間(ms)
     const cardWait = Math.max(0, cardAnimEndsAtRef.current - Date.now())
+    const resultAt = cardWait + RESULT_DELAY
     const t0 = window.setTimeout(() => setSdStep(0), 0)
     const t1 = window.setTimeout(() => setSdStep(1), cardWait)
-    const t2 = window.setTimeout(() => setSdStep(2), cardWait + 800)
-    const t3 = window.setTimeout(() => setSdStep(3), cardWait + 1600)
+    const t2 = window.setTimeout(() => setSdStep(2), resultAt - 300)
+    const t3 = window.setTimeout(() => setSdStep(3), resultAt)
     return () => {
       window.clearTimeout(t0)
       window.clearTimeout(t1)

--- a/mapoker-frontend/src/components/GameScreen/TopBar.tsx
+++ b/mapoker-frontend/src/components/GameScreen/TopBar.tsx
@@ -14,13 +14,14 @@ type Props = {
   onToggleStackMode: () => void
   onCopyInvite: () => void
   onOpenMyPage: () => void
+  onOpenActionLog: () => void
 }
 
 export function TopBar({
   game, mySeatIndex, canAct, displayName,
   error, autoRefresh, setAutoRefresh,
   inviteCopied, stackMode, onToggleStackMode,
-  onCopyInvite, onOpenMyPage,
+  onCopyInvite, onOpenMyPage, onOpenActionLog,
 }: Props) {
   const bb = game?.big_blind ?? 0
   const fmt = (chips: number) => {
@@ -89,6 +90,9 @@ export function TopBar({
             ? <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
             : <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
           }
+        </button>
+        <button className="icon-btn" onClick={onOpenActionLog} data-label="アクションログ">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true"><path d="M9 5H7a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2h-2"/><rect x="9" y="3" width="6" height="4" rx="1"/><line x1="9" y1="12" x2="15" y2="12"/><line x1="9" y1="16" x2="13" y2="16"/></svg>
         </button>
         <button className="icon-btn" onClick={onOpenMyPage} data-label="マイページ">
           <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>

--- a/mapoker-frontend/src/components/GameScreen/index.tsx
+++ b/mapoker-frontend/src/components/GameScreen/index.tsx
@@ -91,6 +91,8 @@ export function GameScreen({
         displayName={displayName}
         onCloseSession={() => {}}
       />
+      <ActionLog game={game} displayName={displayName} />
+
       <ActionPanel
         game={game}
         mySeatIndex={mySeatIndex}
@@ -108,8 +110,6 @@ export function GameScreen({
         displayName={displayName}
         onSendAction={onSendAction}
       />
-
-      <ActionLog game={game} displayName={displayName} />
 
       {/* 退席ボタン・退席予約メッセージ — 右下固定 */}
       <div className="leave-area">

--- a/mapoker-frontend/src/components/GameScreen/index.tsx
+++ b/mapoker-frontend/src/components/GameScreen/index.tsx
@@ -123,6 +123,8 @@ export function GameScreen({
 
       <ActionLogDialog
         game={game}
+        showdown={showdown}
+        payoutLines={payoutLines}
         displayName={displayName}
         open={logOpen}
         onClose={() => setLogOpen(false)}

--- a/mapoker-frontend/src/components/GameScreen/index.tsx
+++ b/mapoker-frontend/src/components/GameScreen/index.tsx
@@ -3,7 +3,7 @@ import type { BetPreset, GameState, PayoutLine, Player, RoomMember, Showdown } f
 import { TopBar } from './TopBar'
 import { TableArea } from './TableArea'
 import { ActionPanel } from './ActionPanel'
-import { ActionLog } from './ActionLog'
+import { ActionLogDialog } from './ActionLog'
 import { t } from '../../i18n'
 
 const STACK_MODE_KEY = 'mapoker_stack_mode'
@@ -55,6 +55,7 @@ export function GameScreen({
   const [stackMode, setStackMode] = useState<'chips' | 'bb'>(() => {
     return (localStorage.getItem(STACK_MODE_KEY) as 'chips' | 'bb') ?? 'chips'
   })
+  const [logOpen, setLogOpen] = useState(false)
 
   useEffect(() => {
     localStorage.setItem(STACK_MODE_KEY, stackMode)
@@ -77,6 +78,7 @@ export function GameScreen({
         onToggleStackMode={toggleStackMode}
         onCopyInvite={onCopyInvite}
         onOpenMyPage={onOpenMyPage}
+        onOpenActionLog={() => setLogOpen(true)}
       />
       <TableArea
         game={game}
@@ -91,8 +93,6 @@ export function GameScreen({
         displayName={displayName}
         onCloseSession={() => {}}
       />
-      <ActionLog game={game} displayName={displayName} />
-
       <ActionPanel
         game={game}
         mySeatIndex={mySeatIndex}
@@ -120,6 +120,13 @@ export function GameScreen({
           {t('leave')}
         </button>
       </div>
+
+      <ActionLogDialog
+        game={game}
+        displayName={displayName}
+        open={logOpen}
+        onClose={() => setLogOpen(false)}
+      />
     </div>
   )
 }

--- a/mapoker-frontend/src/components/GameScreen/index.tsx
+++ b/mapoker-frontend/src/components/GameScreen/index.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react'
-import type { BetPreset, GameState, PayoutLine, Player, RoomMember, Showdown } from '../../types'
+import type { BetPreset, GameState, Player, RoomMember, Showdown, PayoutLine } from '../../types'
 import { TopBar } from './TopBar'
 import { TableArea } from './TableArea'
 import { ActionPanel } from './ActionPanel'
 import { ActionLogDialog } from './ActionLog'
+
 import { t } from '../../i18n'
 
 const STACK_MODE_KEY = 'mapoker_stack_mode'
@@ -123,8 +124,6 @@ export function GameScreen({
 
       <ActionLogDialog
         game={game}
-        showdown={showdown}
-        payoutLines={payoutLines}
         displayName={displayName}
         open={logOpen}
         onClose={() => setLogOpen(false)}

--- a/mapoker-frontend/src/components/GameScreen/index.tsx
+++ b/mapoker-frontend/src/components/GameScreen/index.tsx
@@ -3,6 +3,7 @@ import type { BetPreset, GameState, PayoutLine, Player, RoomMember, Showdown } f
 import { TopBar } from './TopBar'
 import { TableArea } from './TableArea'
 import { ActionPanel } from './ActionPanel'
+import { ActionLog } from './ActionLog'
 import { t } from '../../i18n'
 
 const STACK_MODE_KEY = 'mapoker_stack_mode'
@@ -107,6 +108,8 @@ export function GameScreen({
         displayName={displayName}
         onSendAction={onSendAction}
       />
+
+      <ActionLog game={game} displayName={displayName} />
 
       {/* 退席ボタン・退席予約メッセージ — 右下固定 */}
       <div className="leave-area">

--- a/mapoker-frontend/src/types.ts
+++ b/mapoker-frontend/src/types.ts
@@ -28,6 +28,13 @@ export type GameState = {
   last_showdown?: Showdown
 }
 
+export type ActionLogEntry = {
+  seq: number
+  player_index: number
+  type: string
+  amount: number
+}
+
 export type Showdown = {
   winners?: number[]
   best_hand?: { rank: string; kickers: string[] } | null

--- a/mapoker-frontend/src/types.ts
+++ b/mapoker-frontend/src/types.ts
@@ -33,6 +33,7 @@ export type ActionLogEntry = {
   player_index: number
   type: string
   amount: number
+  label?: string | null
 }
 
 export type Showdown = {


### PR DESCRIPTION
## Summary

**Issue 対応**
- **#61**: チェック可能時（`toCall === 0`）フォールドボタンを `disabled` 化
- **#60**: レイズ額スライダーに −/+ ボタン追加（1BB 単位、min/max クランプ）
- **#59**: TopBar のログボタンでダイアログを開くアクションログ（ショーダウン結果・ペイアウト含め永続化）
- **#62**: 1時間以上無人のテーブルを自動削除（10分ごとにチェック、Spring Scheduler）

**退席・キャッシュアウト漏れ修正**
- ログアウト前にテーブル退席 API を呼びキャッシュアウトを保証
- 再入場時: ハンド非進行中に古いスタックが残っている場合（切断等）を検知し、キャッシュアウト＋スタック初期化してから新バイインを適用
- WebSocket 切断後 30 秒の猶予を経て自動退席（再接続でキャンセル）

**アクションログ**
- `ActionType` に `SHOWDOWN`・`PAYOUT` 追加
- ショーダウン結果・ペイアウトを DB に永続化（V11 migration）
- 二重書き込み防止の冪等ガード
- ショーダウン完了後のみ表示（ネタバレ防止）

**その他 UI**
- ショーダウン result 表示をカードアニメーション完了後 1500ms に変更

## Test plan

- [x] チェック可能時にフォールドボタンが disabled
- [x] −/+ ボタンで 1BB 単位でレイズ額が変わる
- [x] ログボタン → ダイアログでアクション履歴・役・ポット獲得が確認できる
- [x] 次のハンド開始後もログが残る
- [x] ログアウト時にスタックが 0 になる
- [x] 再入場時に前のスタックが引き継がれない
- [x] 1時間後にテーブルがロビーから消える

🤖 Generated with [Claude Code](https://claude.com/claude-code)