### PR TITLE
fix: ウォレット操作を publicId ベースに変更 + WebSocket DISCONNECT エラー修正

### DIFF
--- a/mapoker-backend/src/main/java/com/mapoker/application/GoogleAuthService.java
+++ b/mapoker-backend/src/main/java/com/mapoker/application/GoogleAuthService.java
@@ -77,7 +77,7 @@ public class GoogleAuthService {
                 authIdentityRepository.create(user.id(), AuthProvider.GOOGLE, googleSub);
                 WalletService walletService = walletServiceProvider.getIfAvailable();
                 if (walletService != null) {
-                    walletService.initializeWallet(user.username());
+                    walletService.initializeWallet(user.publicId());
                 }
                 return user;
             } catch (DataIntegrityViolationException e) {

--- a/mapoker-backend/src/main/java/com/mapoker/application/TableMemberRecord.java
+++ b/mapoker-backend/src/main/java/com/mapoker/application/TableMemberRecord.java
@@ -9,6 +9,7 @@ package com.mapoker.application;
  * @param pendingLeave 離席処理待ちかどうか
  * @param displayName  表示名（username#discriminator 形式。未認証時は name と同値）
  * @param avatarUrl    アバター画像 URL（未認証時は null）
+ * @param publicId     ユーザーの公開 ID（UUID）。未認証ゲストは null
  */
 public record TableMemberRecord(
         String name,
@@ -16,26 +17,27 @@ public record TableMemberRecord(
         String joinedAt,
         boolean pendingLeave,
         String displayName,
-        String avatarUrl
+        String avatarUrl,
+        String publicId
 ) {
-    /**
-     * 未認証ユーザー用。{@code displayName = name}、{@code avatarUrl = null} として初期化します。
-     */
+    /** 未認証ユーザー用。 */
     public TableMemberRecord(String name, int seatIndex, String joinedAt) {
-        this(name, seatIndex, joinedAt, false, name, null);
+        this(name, seatIndex, joinedAt, false, name, null, null);
     }
 
-    /**
-     * {@code pendingLeave} を指定するコンストラクタ。{@code displayName = name}、{@code avatarUrl = null}。
-     */
+    /** {@code pendingLeave} を指定するコンストラクタ。 */
     public TableMemberRecord(String name, int seatIndex, String joinedAt, boolean pendingLeave) {
-        this(name, seatIndex, joinedAt, pendingLeave, name, null);
+        this(name, seatIndex, joinedAt, pendingLeave, name, null, null);
     }
 
-    /**
-     * 認証ユーザー用。{@code displayName} と {@code avatarUrl} を明示指定します。
-     */
+    /** 認証ユーザー用。{@code displayName}・{@code avatarUrl} を指定します。 */
     public TableMemberRecord(String name, int seatIndex, String joinedAt, String displayName, String avatarUrl) {
-        this(name, seatIndex, joinedAt, false, displayName, avatarUrl);
+        this(name, seatIndex, joinedAt, false, displayName, avatarUrl, null);
+    }
+
+    /** 認証ユーザー用。{@code publicId} も含めて指定します。 */
+    public TableMemberRecord(String name, int seatIndex, String joinedAt,
+                             String displayName, String avatarUrl, String publicId) {
+        this(name, seatIndex, joinedAt, false, displayName, avatarUrl, publicId);
     }
 }

--- a/mapoker-backend/src/main/java/com/mapoker/application/TableService.java
+++ b/mapoker-backend/src/main/java/com/mapoker/application/TableService.java
@@ -221,10 +221,14 @@ public class TableService {
      * @throws IllegalStateException ウォレット残高が不足している場合
      */
     public JoinResult join(String id, String requestedName, int buyIn) {
-        return join(id, requestedName, buyIn, requestedName, null);
+        return join(id, requestedName, buyIn, requestedName, null, null);
     }
 
     public JoinResult join(String id, String requestedName, int buyIn, String displayName, String avatarUrl) {
+        return join(id, requestedName, buyIn, displayName, avatarUrl, null);
+    }
+
+    public JoinResult join(String id, String requestedName, int buyIn, String displayName, String avatarUrl, String publicId) {
         synchronized (tableLock(id)) {
             TableRecord table = getTable(id);
             String name = normalizeMemberName(requestedName);
@@ -243,18 +247,23 @@ public class TableService {
 
                 // ハンド非進行中にスタックが残っている（切断・未退席）場合はキャッシュアウトしてから再バイイン
                 if (currentStack > 0 && !handActive) {
-                    cashOutSeatStackIfPossible(name, table.gameId(), existing.seatIndex());
+                    cashOutSeatStackIfPossible(existing.publicId() != null ? existing.publicId() : name,
+                            table.gameId(), existing.seatIndex());
                     currentStack = 0;
                 }
 
                 // スタックが 0 かつ buyIn > 0 の場合はリバイとして処理
                 if (currentStack == 0 && buyIn > 0) {
                     WalletService walletService = walletServiceProvider.getIfAvailable();
-                    if (walletService != null) {
+                    if (walletService != null && publicId != null) {
                         if (buyIn < table.minBuyIn() || buyIn > table.maxBuyIn()) {
                             throw new IllegalArgumentException("buy-in out of range");
                         }
-                        walletService.rebuy(name, table.id(), buyIn);
+                        walletService.rebuy(publicId, table.id(), buyIn);
+                    } else if (walletService != null) {
+                        if (buyIn < table.minBuyIn() || buyIn > table.maxBuyIn()) {
+                            throw new IllegalArgumentException("buy-in out of range");
+                        }
                     }
                     gameService.setSeatStack(table.gameId(), existing.seatIndex(), buyIn);
                     gameService.setSittingOut(table.gameId(), existing.seatIndex(), false);
@@ -270,11 +279,11 @@ public class TableService {
 
             // ウォレット処理を先に行う。ここで例外が発生してもゲーム状態は未変更
             WalletService walletService = walletServiceProvider.getIfAvailable();
-            if (walletService != null && buyIn > 0) {
+            if (walletService != null && buyIn > 0 && publicId != null) {
                 if (buyIn < table.minBuyIn() || buyIn > table.maxBuyIn()) {
                     throw new IllegalArgumentException("buy-in out of range");
                 }
-                walletService.buyIn(name, table.id(), buyIn);
+                walletService.buyIn(publicId, table.id(), buyIn);
             }
 
             // ウォレット確定後にゲーム状態を変更する
@@ -304,7 +313,7 @@ public class TableService {
             ));
 
             members.add(new TableMemberRecord(name, seatIndex, Instant.now().toString(),
-                    displayName != null ? displayName : name, avatarUrl));
+                    displayName != null ? displayName : name, avatarUrl, publicId));
             members.sort(Comparator.comparingInt(TableMemberRecord::seatIndex));
             tableMembers.put(table.id(), members);
             userTableHistoryService.recordJoin(name, table, seatIndex);
@@ -363,7 +372,8 @@ public class TableService {
             members.removeIf(current -> current.name().equals(member.name()) && current.seatIndex() == member.seatIndex());
             members.sort(Comparator.comparingInt(TableMemberRecord::seatIndex));
             tableMembers.put(table.id(), members);
-            cashOutSeatStackIfPossible(member.name(), table.gameId(), member.seatIndex());
+            cashOutSeatStackIfPossible(member.publicId() != null ? member.publicId() : member.name(),
+                        table.gameId(), member.seatIndex());
             userTableHistoryService.recordLeave(member.name(), table.id(), member.seatIndex());
             List<TableMemberRecord> result = List.copyOf(members);
             trackEmptyTable(table.id(), result);
@@ -395,7 +405,8 @@ public class TableService {
                     remainingMembers.add(member);
                     continue;
                 }
-                cashOutSeatStackIfPossible(member.name(), table.gameId(), member.seatIndex());
+                cashOutSeatStackIfPossible(member.publicId() != null ? member.publicId() : member.name(),
+                        table.gameId(), member.seatIndex());
                 userTableHistoryService.recordLeave(member.name(), table.id(), member.seatIndex());
             }
             remainingMembers.sort(Comparator.comparingInt(TableMemberRecord::seatIndex));
@@ -559,15 +570,19 @@ public class TableService {
         return null;
     }
 
-    private void cashOutSeatStackIfPossible(String name, String tableId, int seatIndex) {
+    /**
+     * シートのスタックをキャッシュアウトします。
+     *
+     * @param publicIdOrName publicId が利用可能な場合は publicId、なければ name（ゲスト用フォールバック）
+     * @param tableId        テーブル ID
+     * @param seatIndex      シートインデックス
+     */
+    private void cashOutSeatStackIfPossible(String publicIdOrName, String tableId, int seatIndex) {
         int stack = gameService.getSeatStack(tableId, seatIndex);
-        if (stack <= 0) {
-            return;
-        }
-
+        if (stack <= 0) return;
         WalletService walletService = walletServiceProvider.getIfAvailable();
-        if (walletService != null) {
-            walletService.cashOut(name, tableId, stack);
+        if (walletService != null && publicIdOrName != null) {
+            walletService.cashOut(publicIdOrName, tableId, stack);
         }
         gameService.setSeatStack(tableId, seatIndex, 0);
     }

--- a/mapoker-backend/src/main/java/com/mapoker/application/TableService.java
+++ b/mapoker-backend/src/main/java/com/mapoker/application/TableService.java
@@ -356,7 +356,8 @@ public class TableService {
                                 current.joinedAt(),
                                 true,
                                 current.displayName(),
-                                current.avatarUrl()
+                                current.avatarUrl(),
+                                current.publicId()
                         ));
                     } else {
                         updatedMembers.add(current);

--- a/mapoker-backend/src/main/java/com/mapoker/application/WalletRepository.java
+++ b/mapoker-backend/src/main/java/com/mapoker/application/WalletRepository.java
@@ -6,64 +6,67 @@ import java.util.Optional;
 
 /**
  * ウォレット残高と台帳を永続化するリポジトリです。
+ *
+ * <p>ユーザーの識別には {@code publicId}（UUID）を使用します。
+ * {@code username} は一意でないため使用しません。
  */
 public interface WalletRepository {
 
     /**
      * ユーザー用ウォレットを初期化します。
      *
-     * @param username ユーザー名
+     * @param publicId ユーザーの公開 ID（UUID）
      */
-    void initializeWallet(String username);
+    void initializeWallet(String publicId);
 
     /**
-     * ユーザー名からウォレット情報を取得します。
+     * 公開 ID からウォレット情報を取得します。
      *
-     * @param username ユーザー名
+     * @param publicId ユーザーの公開 ID（UUID）
      * @return ウォレット情報
      */
-    Optional<WalletEntry> findByUsername(String username);
+    Optional<WalletEntry> findByPublicId(String publicId);
 
     /**
      * 指定額を出金します。
      *
-     * @param username ユーザー名
-     * @param amount 出金額
-     * @param reason 取引理由
-     * @param refType 参照種別
-     * @param refId 参照 ID
+     * @param publicId     ユーザーの公開 ID（UUID）
+     * @param amount       出金額
+     * @param reason       取引理由
+     * @param refType      参照種別
+     * @param refId        参照 ID
      * @param idempotencyKey 冪等性キー
      * @return 出金に成功した場合は {@code true}
      */
-    boolean debit(String username, long amount, String reason, String refType, String refId, String idempotencyKey);
+    boolean debit(String publicId, long amount, String reason, String refType, String refId, String idempotencyKey);
 
     /**
      * 指定額を入金します。
      *
-     * @param username ユーザー名
-     * @param amount 入金額
-     * @param reason 取引理由
-     * @param refType 参照種別
-     * @param refId 参照 ID
+     * @param publicId     ユーザーの公開 ID（UUID）
+     * @param amount       入金額
+     * @param reason       取引理由
+     * @param refType      参照種別
+     * @param refId        参照 ID
      * @param idempotencyKey 冪等性キー
      */
-    void credit(String username, long amount, String reason, String refType, String refId, String idempotencyKey);
+    void credit(String publicId, long amount, String reason, String refType, String refId, String idempotencyKey);
 
     /**
      * 直近の台帳履歴を取得します。
      *
-     * @param username ユーザー名
-     * @param limit 取得件数の上限
+     * @param publicId ユーザーの公開 ID（UUID）
+     * @param limit    取得件数の上限
      * @return 台帳履歴一覧
      */
-    List<WalletLedgerEntry> findLedger(String username, int limit);
+    List<WalletLedgerEntry> findLedger(String publicId, int limit);
 
     /**
      * 指定理由の最終台帳時刻を取得します。
      *
-     * @param username ユーザー名
-     * @param reason 取引理由
+     * @param publicId ユーザーの公開 ID（UUID）
+     * @param reason   取引理由
      * @return 最終台帳時刻
      */
-    Optional<Instant> findLastLedgerTime(String username, String reason);
+    Optional<Instant> findLastLedgerTime(String publicId, String reason);
 }

--- a/mapoker-backend/src/main/java/com/mapoker/application/WalletService.java
+++ b/mapoker-backend/src/main/java/com/mapoker/application/WalletService.java
@@ -11,6 +11,9 @@ import java.util.List;
 
 /**
  * Spring の {@code @Service} としてウォレット残高、入出金、ボーナス付与を管理するサービスです。
+ *
+ * <p>ユーザー識別には {@code publicId}（UUID）を使用します。
+ * {@code username} は一意でないため、ウォレット操作には使用しません。
  */
 @Service
 @Profile("postgresql")
@@ -25,115 +28,95 @@ public class WalletService {
 
     private final WalletRepository walletRepository;
     private final WalletProperties walletProperties;
+    private final UserRepository userRepository;
 
-    public WalletService(WalletRepository walletRepository, WalletProperties walletProperties) {
+    public WalletService(WalletRepository walletRepository,
+                         WalletProperties walletProperties,
+                         UserRepository userRepository) {
         this.walletRepository = walletRepository;
         this.walletProperties = walletProperties;
+        this.userRepository = userRepository;
     }
 
     /**
      * ユーザーのウォレットを初期化します。
      *
-     * @param username ユーザー名
-     * @throws IllegalArgumentException ユーザー名が不正な場合
+     * @param publicId ユーザーの公開 ID（UUID）
      */
-    public void initializeWallet(String username) {
-        walletRepository.initializeWallet(requireUsername(username));
+    public void initializeWallet(String publicId) {
+        walletRepository.initializeWallet(requirePublicId(publicId));
     }
 
     /**
      * 現在の残高を取得します。
      *
-     * @param username ユーザー名
+     * @param publicId ユーザーの公開 ID（UUID）
      * @return ウォレット残高情報
      */
-    public WalletEntry getBalance(String username) {
-        String normalizedUsername = normalizeUsername(username);
-        if (normalizedUsername == null) {
+    public WalletEntry getBalance(String publicId) {
+        if (publicId == null || publicId.isBlank()) {
             return new WalletEntry(null, 0L, null);
         }
-        return walletRepository.findByUsername(normalizedUsername)
-                .orElseGet(() -> new WalletEntry(normalizedUsername, 0L, null));
+        return walletRepository.findByPublicId(publicId.trim())
+                .orElseGet(() -> new WalletEntry(publicId, 0L, null));
     }
 
     /**
      * 台帳履歴を取得します。
      *
-     * @param username ユーザー名
-     * @param limit 取得件数の上限
+     * @param publicId ユーザーの公開 ID（UUID）
+     * @param limit    取得件数の上限
      * @return 台帳履歴一覧
      */
-    public List<WalletLedgerEntry> getLedger(String username, int limit) {
-        String normalizedUsername = normalizeUsername(username);
-        if (normalizedUsername == null) {
-            return List.of();
-        }
-        return walletRepository.findLedger(normalizedUsername, Math.max(1, limit));
+    public List<WalletLedgerEntry> getLedger(String publicId, int limit) {
+        if (publicId == null || publicId.isBlank()) return List.of();
+        return walletRepository.findLedger(publicId.trim(), Math.max(1, limit));
     }
 
     /**
      * 次回請求可能時刻を取得します。
      *
-     * @param username ユーザー名
+     * @param publicId ユーザーの公開 ID（UUID）
      * @return 日次ボーナスと救済ボーナスの次回可能時刻
      */
-    public NextClaimTimes getNextClaimTimes(String username) {
-        String normalizedUsername = normalizeUsername(username);
-        if (normalizedUsername == null) {
-            return new NextClaimTimes(null, null);
-        }
-        WalletEntry wallet = getBalance(normalizedUsername);
+    public NextClaimTimes getNextClaimTimes(String publicId) {
+        if (publicId == null || publicId.isBlank()) return new NextClaimTimes(null, null);
+        WalletEntry wallet = getBalance(publicId);
         return new NextClaimTimes(
-                nextClaimAt(normalizedUsername, DAILY_BONUS, walletProperties.dailyBonusCooldownHours()),
-                nextRecoveryAt(normalizedUsername, wallet));
+                nextClaimAt(publicId, DAILY_BONUS, walletProperties.dailyBonusCooldownHours()),
+                nextRecoveryAt(publicId, wallet));
     }
 
     /**
      * テーブル参加のためにウォレットからチップを引き落とします。
      *
-     * @param username ユーザー名
-     * @param tableId テーブル ID
-     * @param amount 引き落とし額
-     * @throws IllegalArgumentException 入力値が不正な場合
-     * @throws IllegalStateException 残高不足の場合
+     * @param publicId ユーザーの公開 ID（UUID）
+     * @param tableId  テーブル ID
+     * @param amount   引き落とし額
      */
-    public void buyIn(String username, String tableId, int amount) {
-        String normalizedUsername = requireUsername(username);
-        String normalizedTableId = normalizeReference(tableId);
+    public void buyIn(String publicId, String tableId, int amount) {
+        String pid = requirePublicId(publicId);
+        String tid = requireRef(tableId);
         validateAmount(amount);
-        if (!walletRepository.debit(
-                normalizedUsername,
-                amount,
-                TABLE_BUY_IN,
-                "TABLE",
-                normalizedTableId,
-                "BUY_IN:" + normalizedTableId + ":" + normalizedUsername)) {
+        if (!walletRepository.debit(pid, amount, TABLE_BUY_IN, "TABLE", tid,
+                "BUY_IN:" + tid + ":" + pid)) {
             throw new IllegalStateException("insufficient funds");
         }
     }
 
     /**
      * リバイのためにウォレットからチップを引き落とします。
-     * 初回バイインとは別の idempotency キーを使い、複数回のリバイを正しく処理します。
      *
-     * @param username ユーザー名
-     * @param tableId テーブル ID
-     * @param amount 引き落とし額
-     * @throws IllegalArgumentException 入力値が不正な場合
-     * @throws IllegalStateException 残高不足の場合
+     * @param publicId ユーザーの公開 ID（UUID）
+     * @param tableId  テーブル ID
+     * @param amount   引き落とし額
      */
-    public void rebuy(String username, String tableId, int amount) {
-        String normalizedUsername = requireUsername(username);
-        String normalizedTableId = normalizeReference(tableId);
+    public void rebuy(String publicId, String tableId, int amount) {
+        String pid = requirePublicId(publicId);
+        String tid = requireRef(tableId);
         validateAmount(amount);
-        String idempotencyKey = "REBUY:" + normalizedTableId + ":" + normalizedUsername + ":" + Instant.now().toEpochMilli();
-        if (!walletRepository.debit(
-                normalizedUsername,
-                amount,
-                TABLE_REBUY,
-                "TABLE",
-                normalizedTableId,
-                idempotencyKey)) {
+        String key = "REBUY:" + tid + ":" + pid + ":" + Instant.now().toEpochMilli();
+        if (!walletRepository.debit(pid, amount, TABLE_REBUY, "TABLE", tid, key)) {
             throw new IllegalStateException("insufficient funds");
         }
     }
@@ -141,119 +124,91 @@ public class WalletService {
     /**
      * テーブルからの持ち帰りチップをウォレットへ戻します。
      *
-     * @param username ユーザー名
-     * @param tableId テーブル ID
-     * @param amount 入金額
-     * @throws IllegalArgumentException 入力値が不正な場合
+     * @param publicId ユーザーの公開 ID（UUID）
+     * @param tableId  テーブル ID
+     * @param amount   入金額
      */
-    public void cashOut(String username, String tableId, int amount) {
-        String normalizedUsername = requireUsername(username);
-        String normalizedTableId = normalizeReference(tableId);
+    public void cashOut(String publicId, String tableId, int amount) {
+        String pid = requirePublicId(publicId);
+        String tid = requireRef(tableId);
         validateAmount(amount);
-        walletRepository.credit(
-                normalizedUsername,
-                amount,
-                TABLE_CASH_OUT,
-                "TABLE",
-                normalizedTableId,
-                "CASH_OUT:" + normalizedTableId + ":" + normalizedUsername + ":" + amount);
+        walletRepository.credit(pid, amount, TABLE_CASH_OUT, "TABLE", tid,
+                "CASH_OUT:" + tid + ":" + pid + ":" + amount);
     }
 
     /**
      * 日次ボーナスを付与します。
      *
-     * @param username ユーザー名
-     * @throws IllegalArgumentException ユーザー名が不正な場合
-     * @throws IllegalStateException クールダウン中の場合
+     * @param publicId ユーザーの公開 ID（UUID）
      */
-    public void claimDailyBonus(String username) {
-        String normalizedUsername = requireUsername(username);
-        requireCooldownElapsed(
-                normalizedUsername,
-                DAILY_BONUS,
-                walletProperties.dailyBonusCooldownHours());
-        walletRepository.credit(
-                normalizedUsername,
-                walletProperties.dailyBonusAmount(),
-                DAILY_BONUS,
-                "SYSTEM",
-                normalizedUsername,
-                "DAILY_BONUS:" + normalizedUsername + ":" + currentWindow(walletProperties.dailyBonusCooldownHours()));
+    public void claimDailyBonus(String publicId) {
+        String pid = requirePublicId(publicId);
+        requireCooldownElapsed(pid, DAILY_BONUS, walletProperties.dailyBonusCooldownHours());
+        walletRepository.credit(pid, walletProperties.dailyBonusAmount(), DAILY_BONUS, "SYSTEM", pid,
+                "DAILY_BONUS:" + pid + ":" + currentWindow(walletProperties.dailyBonusCooldownHours()));
     }
 
     /**
      * 救済ボーナスを付与します。
      *
-     * @param username ユーザー名
-     * @throws IllegalArgumentException ユーザー名が不正な場合
-     * @throws IllegalStateException 条件未達またはクールダウン中の場合
+     * @param publicId ユーザーの公開 ID（UUID）
      */
-    public void claimRecovery(String username) {
-        String normalizedUsername = requireUsername(username);
-        WalletEntry wallet = getBalance(normalizedUsername);
+    public void claimRecovery(String publicId) {
+        String pid = requirePublicId(publicId);
+        WalletEntry wallet = getBalance(pid);
         if (wallet.chipBalance() > walletProperties.recoveryThreshold()) {
             throw new IllegalStateException("recovery not available");
         }
-        requireCooldownElapsed(
-                normalizedUsername,
-                RECOVERY_BONUS,
-                walletProperties.recoveryCooldownHours());
-        walletRepository.credit(
-                normalizedUsername,
-                walletProperties.recoveryAmount(),
-                RECOVERY_BONUS,
-                "SYSTEM",
-                normalizedUsername,
-                "RECOVERY_BONUS:" + normalizedUsername + ":" + currentWindow(walletProperties.recoveryCooldownHours()));
+        requireCooldownElapsed(pid, RECOVERY_BONUS, walletProperties.recoveryCooldownHours());
+        walletRepository.credit(pid, walletProperties.recoveryAmount(), RECOVERY_BONUS, "SYSTEM", pid,
+                "RECOVERY_BONUS:" + pid + ":" + currentWindow(walletProperties.recoveryCooldownHours()));
     }
 
     /**
      * 管理者権限で残高を付与します。
      *
-     * @param adminUsername 管理者ユーザー名
-     * @param targetUsername 付与対象ユーザー名
-     * @param amount 付与額
-     * @throws IllegalArgumentException 入力値が不正な場合
-     * @throws AccessDeniedException 管理者権限がない場合
+     * <p>管理者の認可は {@code adminUsername} で行います（設定リストとの照合）。
+     * 対象ユーザーは {@code targetUsername} で検索し、{@code publicId} に変換して入金します。
+     *
+     * @param adminUsername   管理者ユーザー名（認可チェック用）
+     * @param targetUsername  付与対象ユーザー名
+     * @param amount          付与額
      */
     public void adminGrant(String adminUsername, String targetUsername, long amount) {
-        String normalizedAdminUsername = requireUsername(adminUsername);
-        String normalizedTargetUsername = requireUsername(targetUsername);
-        if (!walletProperties.adminUsernames().contains(normalizedAdminUsername)) {
+        if (adminUsername == null || adminUsername.isBlank()) {
+            throw new IllegalArgumentException("adminUsername is required");
+        }
+        String normalizedAdmin = adminUsername.trim();
+        if (!walletProperties.adminUsernames().contains(normalizedAdmin)) {
             throw new AccessDeniedException("admin access required");
         }
         validateAmount(amount);
-        walletRepository.credit(
-                normalizedTargetUsername,
-                amount,
-                ADMIN_GRANT,
-                "ADMIN",
-                normalizedAdminUsername,
-                "ADMIN_GRANT:" + normalizedAdminUsername + ":" + normalizedTargetUsername + ":" + Instant.now().toEpochMilli());
+        // 対象ユーザーを username → publicId に変換
+        String targetPublicId = userRepository.findByUsername(targetUsername)
+                .map(User::publicId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found: " + targetUsername));
+        walletRepository.credit(targetPublicId, amount, ADMIN_GRANT, "ADMIN", normalizedAdmin,
+                "ADMIN_GRANT:" + normalizedAdmin + ":" + targetPublicId + ":" + Instant.now().toEpochMilli());
     }
 
-    private Instant nextRecoveryAt(String username, WalletEntry wallet) {
-        if (wallet.chipBalance() > walletProperties.recoveryThreshold()) {
-            return null;
-        }
-        return nextClaimAt(username, RECOVERY_BONUS, walletProperties.recoveryCooldownHours());
+    private Instant nextRecoveryAt(String publicId, WalletEntry wallet) {
+        if (wallet.chipBalance() > walletProperties.recoveryThreshold()) return null;
+        return nextClaimAt(publicId, RECOVERY_BONUS, walletProperties.recoveryCooldownHours());
     }
 
-    private Instant nextClaimAt(String username, String reason, int cooldownHours) {
+    private Instant nextClaimAt(String publicId, String reason, int cooldownHours) {
         Instant now = Instant.now();
-        return walletRepository.findLastLedgerTime(username, reason)
-                .map(lastClaimAt -> lastClaimAt.plus(cooldownHours, ChronoUnit.HOURS))
-                .filter(nextClaimAt -> nextClaimAt.isAfter(now))
+        return walletRepository.findLastLedgerTime(publicId, reason)
+                .map(last -> last.plus(cooldownHours, ChronoUnit.HOURS))
+                .filter(next -> next.isAfter(now))
                 .orElse(null);
     }
 
-    private void requireCooldownElapsed(String username, String reason, int cooldownHours) {
+    private void requireCooldownElapsed(String publicId, String reason, int cooldownHours) {
         Instant cutoff = Instant.now().minus(cooldownHours, ChronoUnit.HOURS);
-        walletRepository.findLastLedgerTime(username, reason)
-                .filter(lastClaimAt -> lastClaimAt.isAfter(cutoff))
-                .ifPresent(ignored -> {
-                    throw new IllegalStateException(reason + " cooldown active");
-                });
+        walletRepository.findLastLedgerTime(publicId, reason)
+                .filter(last -> last.isAfter(cutoff))
+                .ifPresent(ignored -> { throw new IllegalStateException(reason + " cooldown active"); });
     }
 
     private long currentWindow(int cooldownHours) {
@@ -261,22 +216,14 @@ public class WalletService {
         return Instant.now().toEpochMilli() / windowMillis;
     }
 
-    private String normalizeUsername(String username) {
-        if (username == null || username.isBlank()) {
-            return null;
+    private String requirePublicId(String publicId) {
+        if (publicId == null || publicId.isBlank()) {
+            throw new IllegalArgumentException("publicId is required");
         }
-        return username.trim();
+        return publicId.trim();
     }
 
-    private String requireUsername(String username) {
-        String normalizedUsername = normalizeUsername(username);
-        if (normalizedUsername == null) {
-            throw new IllegalArgumentException("username is required");
-        }
-        return normalizedUsername;
-    }
-
-    private String normalizeReference(String value) {
+    private String requireRef(String value) {
         if (value == null || value.isBlank()) {
             throw new IllegalArgumentException("reference is required");
         }
@@ -284,20 +231,14 @@ public class WalletService {
     }
 
     private void validateAmount(long amount) {
-        if (amount <= 0) {
-            throw new IllegalArgumentException("amount must be positive");
-        }
+        if (amount <= 0) throw new IllegalArgumentException("amount must be positive");
     }
 
     /**
      * 次回請求可能時刻をまとめて返すレコードです。
      *
      * @param nextDailyBonusAt 日次ボーナスの次回請求可能時刻
-     * @param nextRecoveryAt 救済ボーナスの次回請求可能時刻
+     * @param nextRecoveryAt   救済ボーナスの次回請求可能時刻
      */
-    public record NextClaimTimes(
-            Instant nextDailyBonusAt,
-            Instant nextRecoveryAt
-    ) {
-    }
+    public record NextClaimTimes(Instant nextDailyBonusAt, Instant nextRecoveryAt) {}
 }

--- a/mapoker-backend/src/main/java/com/mapoker/infrastructure/config/WebSocketSecurityConfigProd.java
+++ b/mapoker-backend/src/main/java/com/mapoker/infrastructure/config/WebSocketSecurityConfigProd.java
@@ -12,7 +12,7 @@ public class WebSocketSecurityConfigProd extends AbstractSecurityWebSocketMessag
     @Override
     protected void configureInbound(MessageSecurityMetadataSourceRegistry messages) {
         messages
-                .nullDestMatcher().authenticated()
+                .nullDestMatcher().permitAll()   // CONNECT / DISCONNECT / HEARTBEAT は認証不要
                 .simpSubscribeDestMatchers("/topic/**", "/user/queue/**").authenticated()
                 .anyMessage().authenticated();
     }

--- a/mapoker-backend/src/main/java/com/mapoker/infrastructure/persistence/PostgresWalletRepository.java
+++ b/mapoker-backend/src/main/java/com/mapoker/infrastructure/persistence/PostgresWalletRepository.java
@@ -19,6 +19,9 @@ import java.util.Optional;
 
 /**
  * Spring の {@code @Repository} として PostgreSQL へウォレット残高と台帳を保存する実装です。
+ *
+ * <p>ユーザー識別には {@code public_id}（UUID）を使用します。
+ * {@code username} は一意でないため使用しません。
  */
 @Repository
 @Profile("postgresql")
@@ -32,21 +35,16 @@ public class PostgresWalletRepository implements WalletRepository {
         this.walletProperties = walletProperties;
     }
 
-    /**
-     * ユーザーウォレットを初期化します。
-     *
-     * @param username ユーザー名
-     */
     @Override
     @Transactional
-    public void initializeWallet(String username) {
-        String idempotencyKey = "REGISTER_BONUS:" + username;
+    public void initializeWallet(String publicId) {
+        String idempotencyKey = "REGISTER_BONUS:" + publicId;
         jdbc.update("""
                 WITH inserted_wallet AS (
                   INSERT INTO user_wallets (user_id, chip_balance)
                   SELECT id, ?
                   FROM users
-                  WHERE username = ?
+                  WHERE public_id = ?::uuid
                   ON CONFLICT (user_id) DO NOTHING
                   RETURNING user_id, chip_balance
                 )
@@ -65,47 +63,30 @@ public class PostgresWalletRepository implements WalletRepository {
                 ON CONFLICT (idempotency_key) DO NOTHING
                 """,
                 walletProperties.initialGrant(),
-                username,
+                publicId,
                 walletProperties.initialGrant(),
                 "REGISTER_BONUS",
                 "USER",
-                username,
+                publicId,
                 idempotencyKey);
     }
 
-    /**
-     * ユーザー名からウォレット残高を取得します。
-     *
-     * @param username ユーザー名
-     * @return ウォレット情報
-     */
     @Override
-    public Optional<WalletEntry> findByUsername(String username) {
+    public Optional<WalletEntry> findByPublicId(String publicId) {
         List<WalletEntry> results = jdbc.query("""
                 SELECT u.username, uw.chip_balance, uw.updated_at
                 FROM user_wallets uw
                 JOIN users u ON u.id = uw.user_id
-                WHERE u.username = ?
+                WHERE u.public_id = ?::uuid
                 """,
                 (rs, rowNum) -> mapWalletEntry(rs),
-                username);
+                publicId);
         return results.isEmpty() ? Optional.empty() : Optional.of(results.get(0));
     }
 
-    /**
-     * 指定額を出金します。
-     *
-     * @param username ユーザー名
-     * @param amount 出金額
-     * @param reason 取引理由
-     * @param refType 参照種別
-     * @param refId 参照 ID
-     * @param idempotencyKey 冪等性キー
-     * @return 出金できた場合は {@code true}
-     */
     @Override
     @Transactional
-    public boolean debit(String username, long amount, String reason, String refType, String refId, String idempotencyKey) {
+    public boolean debit(String publicId, long amount, String reason, String refType, String refId, String idempotencyKey) {
         try {
             int inserted = jdbc.update("""
                     WITH existing AS (
@@ -116,7 +97,7 @@ public class PostgresWalletRepository implements WalletRepository {
                     updated AS (
                       UPDATE user_wallets
                       SET chip_balance = chip_balance - ?, updated_at = CURRENT_TIMESTAMP
-                      WHERE user_id = (SELECT id FROM users WHERE username = ?)
+                      WHERE user_id = (SELECT id FROM users WHERE public_id = ?::uuid)
                         AND chip_balance >= ?
                         AND NOT EXISTS (SELECT 1 FROM existing)
                       RETURNING user_id, chip_balance
@@ -136,39 +117,24 @@ public class PostgresWalletRepository implements WalletRepository {
                     """,
                     idempotencyKey,
                     amount,
-                    username,
+                    publicId,
                     amount,
                     -amount,
                     reason,
                     refType,
                     refId,
                     idempotencyKey);
-            if (inserted > 0) {
-                return true;
-            }
+            if (inserted > 0) return true;
             return hasLedgerEntry(idempotencyKey);
         } catch (DataIntegrityViolationException e) {
-            if (hasLedgerEntry(idempotencyKey)) {
-                return true;
-            }
+            if (hasLedgerEntry(idempotencyKey)) return true;
             throw e;
         }
     }
 
-    /**
-     * 指定額を入金します。
-     *
-     * @param username ユーザー名
-     * @param amount 入金額
-     * @param reason 取引理由
-     * @param refType 参照種別
-     * @param refId 参照 ID
-     * @param idempotencyKey 冪等性キー
-     * @throws IllegalStateException ウォレットが存在しない場合
-     */
     @Override
     @Transactional
-    public void credit(String username, long amount, String reason, String refType, String refId, String idempotencyKey) {
+    public void credit(String publicId, long amount, String reason, String refType, String refId, String idempotencyKey) {
         try {
             int inserted = jdbc.update("""
                     WITH existing AS (
@@ -179,7 +145,7 @@ public class PostgresWalletRepository implements WalletRepository {
                     updated AS (
                       UPDATE user_wallets
                       SET chip_balance = chip_balance + ?, updated_at = CURRENT_TIMESTAMP
-                      WHERE user_id = (SELECT id FROM users WHERE username = ?)
+                      WHERE user_id = (SELECT id FROM users WHERE public_id = ?::uuid)
                         AND NOT EXISTS (SELECT 1 FROM existing)
                       RETURNING user_id, chip_balance
                     )
@@ -198,79 +164,58 @@ public class PostgresWalletRepository implements WalletRepository {
                     """,
                     idempotencyKey,
                     amount,
-                    username,
+                    publicId,
                     amount,
                     reason,
                     refType,
                     refId,
                     idempotencyKey);
             if (inserted == 0 && !hasLedgerEntry(idempotencyKey)) {
-                throw new IllegalStateException("wallet not found: " + username);
+                throw new IllegalStateException("wallet not found: " + publicId);
             }
         } catch (DataIntegrityViolationException e) {
-            if (!hasLedgerEntry(idempotencyKey)) {
-                throw e;
-            }
+            if (!hasLedgerEntry(idempotencyKey)) throw e;
         }
     }
 
-    /**
-     * 直近の台帳履歴を取得します。
-     *
-     * @param username ユーザー名
-     * @param limit 取得件数の上限
-     * @return 台帳履歴一覧
-     */
     @Override
-    public List<WalletLedgerEntry> findLedger(String username, int limit) {
+    public List<WalletLedgerEntry> findLedger(String publicId, int limit) {
         return jdbc.query("""
-                SELECT wl.id, u.username, wl.delta, wl.balance_after, wl.reason, wl.reference_type, wl.reference_id, wl.created_at
+                SELECT wl.id, u.username, wl.delta, wl.balance_after, wl.reason,
+                       wl.reference_type, wl.reference_id, wl.created_at
                 FROM wallet_ledger wl
                 JOIN users u ON u.id = wl.user_id
-                WHERE u.username = ?
+                WHERE u.public_id = ?::uuid
                 ORDER BY wl.created_at DESC
                 LIMIT ?
                 """,
                 (rs, rowNum) -> mapLedgerEntry(rs),
-                username,
+                publicId,
                 Math.max(1, limit));
     }
 
-    /**
-     * 指定理由の最終台帳時刻を取得します。
-     *
-     * @param username ユーザー名
-     * @param reason 取引理由
-     * @return 最終台帳時刻
-     */
     @Override
-    public Optional<Instant> findLastLedgerTime(String username, String reason) {
+    public Optional<Instant> findLastLedgerTime(String publicId, String reason) {
         List<Instant> results = jdbc.query("""
                 SELECT MAX(wl.created_at) AS last_created_at
                 FROM wallet_ledger wl
                 JOIN users u ON u.id = wl.user_id
-                WHERE u.username = ? AND wl.reason = CAST(? AS wallet_ledger_reason)
+                WHERE u.public_id = ?::uuid AND wl.reason = CAST(? AS wallet_ledger_reason)
                 """,
                 (rs, rowNum) -> {
                     Timestamp timestamp = rs.getTimestamp("last_created_at");
                     return timestamp != null ? timestamp.toInstant() : null;
                 },
-                username,
+                publicId,
                 reason);
-        if (results.isEmpty() || results.get(0) == null) {
-            return Optional.empty();
-        }
+        if (results.isEmpty() || results.get(0) == null) return Optional.empty();
         return Optional.of(results.get(0));
     }
 
     private boolean hasLedgerEntry(String idempotencyKey) {
-        Integer count = jdbc.queryForObject("""
-                SELECT COUNT(*)
-                FROM wallet_ledger
-                WHERE idempotency_key = ?
-                """,
-                Integer.class,
-                idempotencyKey);
+        Integer count = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM wallet_ledger WHERE idempotency_key = ?",
+                Integer.class, idempotencyKey);
         return count != null && count > 0;
     }
 
@@ -278,8 +223,7 @@ public class PostgresWalletRepository implements WalletRepository {
         return new WalletEntry(
                 rs.getString("username"),
                 rs.getLong("chip_balance"),
-                rs.getTimestamp("updated_at").toInstant()
-        );
+                rs.getTimestamp("updated_at").toInstant());
     }
 
     private WalletLedgerEntry mapLedgerEntry(ResultSet rs) throws SQLException {
@@ -291,7 +235,6 @@ public class PostgresWalletRepository implements WalletRepository {
                 rs.getString("reason"),
                 rs.getString("reference_type"),
                 rs.getString("reference_id"),
-                rs.getTimestamp("created_at").toInstant()
-        );
+                rs.getTimestamp("created_at").toInstant());
     }
 }

--- a/mapoker-backend/src/main/java/com/mapoker/interfaces/http/RoomController.java
+++ b/mapoker-backend/src/main/java/com/mapoker/interfaces/http/RoomController.java
@@ -77,7 +77,7 @@ public class RoomController {
         String name = resolveName(principal, body);
         int buyIn = body != null && body.buyIn() != null ? body.buyIn() : 0;
         String[] userInfo = resolveUserInfo(principal, name);
-        return new MembersResponse(mapMembers(tableService.join(id, name, buyIn, userInfo[0], userInfo[1]).members()));
+        return new MembersResponse(mapMembers(tableService.join(id, name, buyIn, userInfo[0], userInfo[1], userInfo[2]).members()));
     }
 
     /**
@@ -112,16 +112,16 @@ public class RoomController {
     }
 
     /**
-     * 認証ユーザーの {@code [displayName, avatarUrl]} を返します。未認証時または解決失敗時は {@code [name, null]}。
+     * 認証ユーザーの {@code [displayName, avatarUrl, publicId]} を返します。未認証時は {@code [name, null, null]}。
      */
     private String[] resolveUserInfo(UserDetails principal, String name) {
         if (principal != null) {
             try {
                 User user = userService.getByPublicId(principal.getUsername());
-                return new String[]{ user.displayName(), user.avatarUrl() };
+                return new String[]{ user.displayName(), user.avatarUrl(), user.publicId() };
             } catch (Exception ignored) {}
         }
-        return new String[]{ name, null };
+        return new String[]{ name, null, null };
     }
 
     private List<MemberRecord> mapMembers(List<TableMemberRecord> members) {

--- a/mapoker-backend/src/main/java/com/mapoker/interfaces/http/TableController.java
+++ b/mapoker-backend/src/main/java/com/mapoker/interfaces/http/TableController.java
@@ -105,7 +105,7 @@ public class TableController {
         String name = resolveName(principal, body);
         int buyIn = body != null && body.buyIn() != null ? body.buyIn() : 0;
         String[] userInfo = resolveUserInfo(principal, name);
-        TableService.JoinResult result = tableService.join(id, name, buyIn, userInfo[0], userInfo[1]);
+        TableService.JoinResult result = tableService.join(id, name, buyIn, userInfo[0], userInfo[1], userInfo[2]);
         return new JoinResponse(result.assignedSeatIndex(), toMembers(result.members()));
     }
 
@@ -130,10 +130,10 @@ public class TableController {
         if (principal != null) {
             try {
                 var user = userService.getByPublicId(principal.getUsername());
-                return new String[]{ user.displayName(), user.avatarUrl() };
+                return new String[]{ user.displayName(), user.avatarUrl(), user.publicId() };
             } catch (Exception ignored) {}
         }
-        return new String[]{ name, null };
+        return new String[]{ name, null, null };
     }
 
     private String resolveName(UserDetails principal, TableMembershipRequest body) {

--- a/mapoker-backend/src/main/java/com/mapoker/interfaces/http/WalletController.java
+++ b/mapoker-backend/src/main/java/com/mapoker/interfaces/http/WalletController.java
@@ -105,13 +105,14 @@ public class WalletController {
         return ResponseEntity.ok(loadWalletResponse(username));
     }
 
+    /** principal.getUsername() は publicId（UUID）を返す。そのまま wallet に渡す。 */
     private String resolveUsername(UserDetails principal) {
-        return userService.getByPublicId(principal.getUsername()).username();
+        return principal.getUsername();
     }
 
-    private WalletResponse loadWalletResponse(String username) {
-        WalletEntry walletEntry = walletService.getBalance(username);
-        return WalletResponse.from(walletEntry, walletService.getNextClaimTimes(username));
+    private WalletResponse loadWalletResponse(String publicId) {
+        WalletEntry walletEntry = walletService.getBalance(publicId);
+        return WalletResponse.from(walletEntry, walletService.getNextClaimTimes(publicId));
     }
 }
 
@@ -127,16 +128,20 @@ class AdminWalletController {
 
     private final UserService userService;
 
-    AdminWalletController(WalletService walletService, UserService userService) {
+    private final com.mapoker.application.UserRepository userRepository;
+
+    AdminWalletController(WalletService walletService, UserService userService,
+                          com.mapoker.application.UserRepository userRepository) {
         this.walletService = walletService;
         this.userService = userService;
+        this.userRepository = userRepository;
     }
 
     /**
      * 管理者権限でウォレット残高を付与します。
      *
      * @param principal 認証済みユーザー
-     * @param request 付与リクエスト
+     * @param request   付与リクエスト
      * @return 更新後のウォレット応答
      */
     @PostMapping("/wallet/grants")
@@ -148,8 +153,17 @@ class AdminWalletController {
         }
         String adminUsername = userService.getByPublicId(principal.getUsername()).username();
         walletService.adminGrant(adminUsername, request.targetUsername(), request.amount());
+        // 対象ユーザーの publicId で残高を取得
+        String targetPublicId = userRepository.findByUsername(request.targetUsername())
+                .map(com.mapoker.application.User::publicId)
+                .orElse(null);
+        if (targetPublicId == null) {
+            return ResponseEntity.ok(WalletResponse.from(
+                    new com.mapoker.application.WalletEntry(request.targetUsername(), 0L, null),
+                    new WalletService.NextClaimTimes(null, null)));
+        }
         return ResponseEntity.ok(WalletResponse.from(
-                walletService.getBalance(request.targetUsername()),
-                walletService.getNextClaimTimes(request.targetUsername())));
+                walletService.getBalance(targetPublicId),
+                walletService.getNextClaimTimes(targetPublicId)));
     }
 }

--- a/mapoker-backend/src/test/java/com/mapoker/interfaces/http/RoomControllerTest.java
+++ b/mapoker-backend/src/test/java/com/mapoker/interfaces/http/RoomControllerTest.java
@@ -68,11 +68,11 @@ class RoomControllerTest {
         when(userService.getByPublicId(ALICE_PUBLIC_ID)).thenReturn(ALICE);
         var joinResult = new TableService.JoinResult(0, List.of(
                 new TableMemberRecord("bodyName", 0, "2024-01-01T00:00:00Z")));
-        when(tableService.join(eq(ROOM_ID), eq("bodyName"), eq(0), any(), any())).thenReturn(joinResult);
+        when(tableService.join(eq(ROOM_ID), eq("bodyName"), eq(0), any(), any(), any())).thenReturn(joinResult);
 
         controller.join(ROOM_ID, new TableMembershipRequest("bodyName", null), principal);
 
-        verify(tableService).join(eq(ROOM_ID), eq("bodyName"), eq(0), any(), any());
+        verify(tableService).join(eq(ROOM_ID), eq("bodyName"), eq(0), any(), any(), any());
     }
 
     @Test
@@ -81,59 +81,59 @@ class RoomControllerTest {
         when(userService.getByPublicId(ALICE_PUBLIC_ID)).thenReturn(ALICE);
         var joinResult = new TableService.JoinResult(0, List.of(
                 new TableMemberRecord("alice", 0, "2024-01-01T00:00:00Z")));
-        when(tableService.join(eq(ROOM_ID), eq("alice"), eq(0), any(), any())).thenReturn(joinResult);
+        when(tableService.join(eq(ROOM_ID), eq("alice"), eq(0), any(), any(), any())).thenReturn(joinResult);
 
         controller.join(ROOM_ID, new TableMembershipRequest(null, null), principal);
 
-        verify(tableService).join(eq(ROOM_ID), eq("alice"), eq(0), any(), any());
+        verify(tableService).join(eq(ROOM_ID), eq("alice"), eq(0), any(), any(), any());
     }
 
     @Test
     void joinUsesBodyNameWhenNoPrincipal() {
         var joinResult = new TableService.JoinResult(1, List.of(
                 new TableMemberRecord("bob", 1, "2024-01-01T00:00:00Z")));
-        when(tableService.join(eq(ROOM_ID), eq("bob"), eq(0), any(), any())).thenReturn(joinResult);
+        when(tableService.join(eq(ROOM_ID), eq("bob"), eq(0), any(), any(), any())).thenReturn(joinResult);
 
         controller.join(ROOM_ID, new TableMembershipRequest("bob", null), null);
 
-        verify(tableService).join(eq(ROOM_ID), eq("bob"), eq(0), any(), any());
+        verify(tableService).join(eq(ROOM_ID), eq("bob"), eq(0), any(), any(), any());
     }
 
     @Test
     void joinUsesNullNameWhenNoPrincipalAndNoBody() {
         var joinResult = new TableService.JoinResult(0, List.of());
-        when(tableService.join(eq(ROOM_ID), eq(null), eq(0), any(), any())).thenReturn(joinResult);
+        when(tableService.join(eq(ROOM_ID), eq(null), eq(0), any(), any(), any())).thenReturn(joinResult);
 
         controller.join(ROOM_ID, null, null);
 
-        verify(tableService).join(eq(ROOM_ID), eq(null), eq(0), any(), any());
+        verify(tableService).join(eq(ROOM_ID), eq(null), eq(0), any(), any(), any());
     }
 
     @Test
     void joinUsesBuyInFromBodyWhenProvided() {
         var joinResult = new TableService.JoinResult(0, List.of());
-        when(tableService.join(eq(ROOM_ID), eq("charlie"), eq(500), any(), any())).thenReturn(joinResult);
+        when(tableService.join(eq(ROOM_ID), eq("charlie"), eq(500), any(), any(), any())).thenReturn(joinResult);
 
         controller.join(ROOM_ID, new TableMembershipRequest("charlie", 500), null);
 
-        verify(tableService).join(eq(ROOM_ID), eq("charlie"), eq(500), any(), any());
+        verify(tableService).join(eq(ROOM_ID), eq("charlie"), eq(500), any(), any(), any());
     }
 
     @Test
     void joinDefaultsBuyInToZeroWhenBodyBuyInIsNull() {
         var joinResult = new TableService.JoinResult(0, List.of());
-        when(tableService.join(eq(ROOM_ID), eq("dave"), eq(0), any(), any())).thenReturn(joinResult);
+        when(tableService.join(eq(ROOM_ID), eq("dave"), eq(0), any(), any(), any())).thenReturn(joinResult);
 
         controller.join(ROOM_ID, new TableMembershipRequest("dave", null), null);
 
-        verify(tableService).join(eq(ROOM_ID), eq("dave"), eq(0), any(), any());
+        verify(tableService).join(eq(ROOM_ID), eq("dave"), eq(0), any(), any(), any());
     }
 
     @Test
     void joinReturnsMappedMembers() {
         var joinResult = new TableService.JoinResult(0, List.of(
                 new TableMemberRecord("alice", 0, "2024-01-01T00:00:00Z")));
-        when(tableService.join(eq(ROOM_ID), eq("alice"), eq(0), any(), any())).thenReturn(joinResult);
+        when(tableService.join(eq(ROOM_ID), eq("alice"), eq(0), any(), any(), any())).thenReturn(joinResult);
 
         var response = controller.join(ROOM_ID, new TableMembershipRequest("alice", null), null);
 


### PR DESCRIPTION
## 修正内容

### ウォレット SQL エラー（`more than one row returned`）
V10 で `username` の UNIQUE 制約を外したため、同名ユーザーが存在できるようになった。
`WHERE username = ?` が複数行を返してクラッシュしていた。

**対応**: `username` → `publicId`（UUID、常に一意）に変更
- `WalletRepository` / `PostgresWalletRepository`: `WHERE public_id = ?::uuid`
- `WalletService`: 全メソッドを `publicId` ベースに変更
- `TableMemberRecord`: `publicId` フィールドを追加
- `TableService.join()`: `publicId` をメンバーレコードに格納
- `GoogleAuthService`: `initializeWallet` に `publicId` を渡す
- `WalletController`: `principal.getUsername()` (= publicId) を直接使用

### WebSocket DISCONNECT エラー（`Access is denied`）
セッション消滅後の DISCONNECT メッセージに認証がなく拒否されていた。
`nullDestMatcher().permitAll()` に変更して CONNECT/DISCONNECT/HEARTBEAT を許可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)