### PR TITLE
fix: Makefile rebuild順修正 + ルートpackage-lock.jsonをgitignore追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ dump.sql
 
 # Upload data (generated at runtime)
 data/
+package-lock.json

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ build:
 	docker compose build --no-cache
 
 rebuild:
-	docker compose down
 	docker compose build --no-cache
+	docker compose down
 	$(MAKE) setup ENV=$(ENV)
 	docker compose $(ENV_FILE) up -d
 


### PR DESCRIPTION
## Summary

- `rebuild` ターゲットの実行順を `down → build` から `build → down` に変更。ビルド中もサービスを継続稼働させてダウンタイムを短縮。
- ルートに誤生成された空の `package-lock.json` を `.gitignore` に追加（`package.json` が存在しないため不要なファイル）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)