### PR TITLE
release: v1.1.2

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,11 +4,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Status
 
-Java 実装は完成・稼働中（v1.0.2）。Go プロジェクト（`/home/taiki/projects/mapoker`）は参照実装として残すが、主体は本リポジトリの Java 実装に移っている。
+Java 実装は完成・稼働中（v1.1.2）。Go プロジェクト（`/home/taiki/projects/mapoker`）は参照実装として残すが、主体は本リポジトリの Java 実装に移っている。
 
 ## Commands
 
-> **重要**: 以下のコマンドはすべてdevcontainer内で実行する必要があります。Claude Codeはdevcontainer内でコマンドを直接実行できないため、実行が必要な場合はユーザーに依頼してください。
+コマンドは `mapoker-backend/` ディレクトリ内で `./mvnw` を使って実行する。
+ホスト環境（WSL2）に OpenJDK 21 + Maven wrapper が設定済みのため、Claude Code から直接実行できる。
 
 ```bash
 # Format
@@ -33,6 +34,9 @@ SPRING_PROFILES_ACTIVE=local,postgresql \
 # DB migration (runs automatically on startup; manual override)
 ./mvnw flyway:migrate
 ```
+
+> **注意**: PostgreSQL が必要なテスト（integration test）や `spring-boot:run` の postgresql プロファイルは、
+> Docker コンテナが起動している必要がある。ユニットテスト（`./mvnw test`）はホスト環境で単独実行可能。
 
 ## フロントエンド設計方針
 

--- a/mapoker-backend/pom.xml
+++ b/mapoker-backend/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.mapoker</groupId>
 	<artifactId>mapoker-backend</artifactId>
-	<version>1.1.1</version>
+	<version>1.1.2</version>
 	<name/>
 	<description/>
 	<url/>


### PR DESCRIPTION
## v1.1.2 リリース内容

### バグ修正
- **バイイン再引き落とし未実施** — 退席後の再入室でチップが引き落とされないバグを修正（冪等性キーにタイムスタンプを追加）
- **pendingLeave 再入室で未解除** — ハンド中に leave → rejoin するとハンド終了後に強制退席されるバグを修正
- **名前変更後に leave できない** — leave を publicId ベースで特定するよう変更
- **テーブル自動削除が無効化** — `listTables()` の `gameService` 再生成で削除済みテーブルが復活する問題を修正
- **buy-in モーダルが詰む** — ウォレット残高 < minBuyIn のとき操作不能になる問題を修正
- **join 失敗で spectator 状態** — join 成功後に画面状態・URL を更新するよう変更
- **Makefile rebuild 順** — `build → down` の順に修正

### 機能廃止
- 回復チップ（`POST /v1/wallet/recovery`）を廃止

### ドキュメント
- `db_schema.md` を V11 まで更新（V9〜V11 追記）
- `API.md` を現在の実装に合わせて更新（Google Auth 対応・recovery 削除）
- 実装済みの `google-auth.md` を削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)