### PR TITLE
fix: 同名プレイヤーによる席乗っ取りを防止

### DIFF
--- a/mapoker-backend/pom.xml
+++ b/mapoker-backend/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.mapoker</groupId>
 	<artifactId>mapoker-backend</artifactId>
-	<version>1.1.3</version>
+	<version>1.1.4</version>
 	<name/>
 	<description/>
 	<url/>

--- a/mapoker-backend/src/main/java/com/mapoker/application/TableService.java
+++ b/mapoker-backend/src/main/java/com/mapoker/application/TableService.java
@@ -268,8 +268,12 @@ public class TableService {
             List<TableMemberRecord> members = new ArrayList<>(tableMembers.computeIfAbsent(table.id(), ignored -> new ArrayList<>()));
             JoinResult result;
 
+            // publicId がある場合は publicId で同一人物を判定する（同名別人による席乗っ取りを防ぐ）
+            // 未認証（ローカルモード）の場合のみ name でフォールバックする
             TableMemberRecord existing = members.stream()
-                    .filter(member -> member.name().equals(name))
+                    .filter(member -> publicId != null
+                            ? publicId.equals(member.publicId())
+                            : member.name().equals(name))
                     .findFirst()
                     .orElse(null);
             if (existing != null) {
@@ -305,8 +309,11 @@ public class TableService {
                 if (existing.pendingLeave()) {
                     int idx = members.indexOf(existing);
                     members.set(idx, new TableMemberRecord(
-                            existing.name(), existing.seatIndex(), existing.joinedAt(),
-                            false, existing.displayName(), existing.avatarUrl(), existing.publicId()));
+                            name, existing.seatIndex(), existing.joinedAt(),
+                            false,
+                            displayName != null ? displayName : existing.displayName(),
+                            avatarUrl != null ? avatarUrl : existing.avatarUrl(),
+                            publicId != null ? publicId : existing.publicId()));
                     tableMembers.put(table.id(), members);
                 }
                 lastEmptiedAt.remove(table.id());

--- a/mapoker-backend/src/main/java/com/mapoker/interfaces/http/RoomController.java
+++ b/mapoker-backend/src/main/java/com/mapoker/interfaces/http/RoomController.java
@@ -98,16 +98,17 @@ public class RoomController {
     }
 
     /**
-     * body.name() を優先し、未指定なら principal の publicId からユーザー名を解決します。
+     * 認証済みユーザーは principal の publicId からユーザー名を解決します（body.name は無視）。
+     * 未認証時のみ body.name を使用します。
      */
     private String resolveName(UserDetails principal, TableMembershipRequest body) {
-        if (body != null && body.name() != null && !body.name().isBlank()) {
-            return body.name();
-        }
         if (principal != null) {
             try {
                 return userService.getByPublicId(principal.getUsername()).username();
             } catch (Exception ignored) {}
+        }
+        if (body != null && body.name() != null && !body.name().isBlank()) {
+            return body.name();
         }
         return null;
     }

--- a/mapoker-backend/src/test/java/com/mapoker/interfaces/http/RoomControllerTest.java
+++ b/mapoker-backend/src/test/java/com/mapoker/interfaces/http/RoomControllerTest.java
@@ -63,16 +63,17 @@ class RoomControllerTest {
     }
 
     @Test
-    void joinUsesBodyNameEvenWhenPrincipalPresent() {
+    void joinIgnoresBodyNameWhenPrincipalPresent() {
         var principal = principalOf(ALICE_PUBLIC_ID);
         when(userService.getByPublicId(ALICE_PUBLIC_ID)).thenReturn(ALICE);
         var joinResult = new TableService.JoinResult(0, List.of(
-                new TableMemberRecord("bodyName", 0, "2024-01-01T00:00:00Z")));
-        when(tableService.join(eq(ROOM_ID), eq("bodyName"), eq(0), any(), any(), any())).thenReturn(joinResult);
+                new TableMemberRecord("alice", 0, "2024-01-01T00:00:00Z")));
+        when(tableService.join(eq(ROOM_ID), eq("alice"), eq(0), any(), any(), any())).thenReturn(joinResult);
 
+        // body に別名を入れても principal のユーザー名が使われる（席乗っ取り防止）
         controller.join(ROOM_ID, new TableMembershipRequest("bodyName", null), principal);
 
-        verify(tableService).join(eq(ROOM_ID), eq("bodyName"), eq(0), any(), any(), any());
+        verify(tableService).join(eq(ROOM_ID), eq("alice"), eq(0), any(), any(), any());
     }
 
     @Test
@@ -143,13 +144,15 @@ class RoomControllerTest {
     }
 
     @Test
-    void leaveUsesBodyNameEvenWhenPrincipalPresent() {
+    void leaveIgnoresBodyNameWhenPrincipalPresent() {
         var principal = principalOf(ALICE_PUBLIC_ID);
-        when(tableService.leave(ROOM_ID, "bodyName", null, ALICE_PUBLIC_ID)).thenReturn(List.of());
+        when(userService.getByPublicId(ALICE_PUBLIC_ID)).thenReturn(ALICE);
+        when(tableService.leave(ROOM_ID, "alice", null, ALICE_PUBLIC_ID)).thenReturn(List.of());
 
+        // body に別名を入れても principal のユーザー名が使われる
         controller.leave(ROOM_ID, new TableMembershipRequest("bodyName", null), principal);
 
-        verify(tableService).leave(ROOM_ID, "bodyName", null, ALICE_PUBLIC_ID);
+        verify(tableService).leave(ROOM_ID, "alice", null, ALICE_PUBLIC_ID);
     }
 
     @Test


### PR DESCRIPTION
## Summary

同じ username を持つ別ユーザーや、body.name に他人の名前を指定することでテーブルの席を乗っ取れるセキュリティバグを修正。

## 修正した脆弱性

**経路 A: 同名ユーザーによる乗っ取り**
- `TableService.join()` の既存メンバー検索が `name` 文字列一致のみだったため、同じ username で discriminator が違う別ユーザーが席を乗っ取れた
- **修正**: `publicId` が一致する場合のみ再接続と判定。未認証（ローカルモード）時のみ name フォールバック

**経路 B: リクエストボディによる任意名指定**
- `resolveName()` が `body.name` を認証ユーザーの名前より優先していたため、認証済みでも他人の名前でリクエストできた
- **修正**: 認証済みユーザーは `body.name` を無視し、`principal` のユーザー名のみを使用

**追加修正: リバイ時の publicId 更新**
- 再接続時の `TableMemberRecord` が古い publicId のままだと、ウォレット操作が元プレイヤーに向く可能性があった
- **修正**: 再接続時に name/displayName/avatarUrl/publicId を最新情報で更新

## 影響範囲

- 経路 C（`SPRING_PROFILES_ACTIVE=local`）は認証なしのため body.name がそのまま使われる動作を維持（開発用途のため許容）

## Test plan

- [ ] `./mvnw test` が全通過すること
- [ ] 同名の別ユーザーがテーブルに参加しても席を乗っ取れないこと
- [ ] body.name に他人の名前を入れても自分の名前で参加されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)