### PR TITLE
refactor: React Router 導入・URL を /table/:tableId に変更（issue #85 Phase 3）

### DIFF
--- a/mapoker-frontend/package-lock.json
+++ b/mapoker-frontend/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "frontend",
-  "version": "1.0.3",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.0.3",
+      "version": "1.1.1",
       "dependencies": {
         "@react-oauth/google": "^0.12.1",
         "@stomp/stompjs": "^7.0.0",
         "react": "^19.2.0",
-        "react-dom": "^19.2.0"
+        "react-dom": "^19.2.0",
+        "react-router-dom": "^7.15.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -1823,6 +1824,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "dev": true,
@@ -2630,6 +2644,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.15.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.15.1.tgz",
+      "integrity": "sha512-R8rl9HhgikFYoPJymnUtPXWbnDb3oget6lQnfIoupbt61aT9aOhRkDsY2XRhZRyX1Z/8a5sL74fXmFNm3NRK5A==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.15.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.15.1.tgz",
+      "integrity": "sha512-AzF62gjY6U9rkMq4RfP/r2EVtQ7DMfNMjyOp/flLTCrtRylLiK4wT4pSq6O8rOXZ2eXdZYJPEYe+ifomiv+Igg==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.15.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "dev": true,
@@ -2692,6 +2744,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/mapoker-frontend/package.json
+++ b/mapoker-frontend/package.json
@@ -13,7 +13,8 @@
     "@react-oauth/google": "^0.12.1",
     "@stomp/stompjs": "^7.0.0",
     "react": "^19.2.0",
-    "react-dom": "^19.2.0"
+    "react-dom": "^19.2.0",
+    "react-router-dom": "^7.15.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/mapoker-frontend/src/App.tsx
+++ b/mapoker-frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { useMatch, useNavigate } from 'react-router-dom'
 import './App.css'
 import {
   apiLogout, createTable, fetchMe, fetchVersion, joinTable, leaveTable,
@@ -29,6 +30,15 @@ const NEXT_HAND_DELAY_MS = 7000
 const CARD_REVEAL_MS_PER_STREET = 1500
 
 function App() {
+  // ---- ルーティング ----
+  const navigate = useNavigate()
+  const match = useMatch('/table/:tableId')
+  const gameId = match?.params.tableId ?? ''
+
+  // gameId への遷移をラップ（URL が正規表現）
+  const goToTable = (id: string) => navigate(`/table/${id}`, { replace: true })
+  const goToLobby = () => navigate('/', { replace: true })
+
   // ---- グローバル state ----
   const [currentUser, setCurrentUser] = useState<AuthUser | null>(null)
   const [appVersion, setAppVersion] = useState('')
@@ -53,8 +63,8 @@ function App() {
   const prevIsMyTurnRef = useRef(false)
 
   // ---- hooks ----
-  const session = useTableSession(roster)
-  const { gameId, setGameId, myName, setMyName, mySeatIndex, setMySeatIndex, mySeat, persistSession, clearGameSession } = session
+  const session = useTableSession(gameId, roster)
+  const { myName, setMyName, mySeatIndex, setMySeatIndex, mySeat, persistSession, clearGameSession } = session
 
   const profile = useProfileData(formatErrorMessage)
   const { wallet, walletLedger, profileTables, profileHistory, profileLoading, profileError, refreshProfileTables, handleClaimDailyBonus } = profile
@@ -72,7 +82,7 @@ function App() {
   }, [game?.players, roster])
 
   const isShowdown = game?.status === 'showdown' || (game?.status === 'finished' && showdown !== null)
-  const inviteUrl = gameId ? `${window.location.origin}?tableId=${gameId}` : ''
+  const inviteUrl = gameId ? `${window.location.origin}/table/${gameId}` : ''
 
   const toCall = useMemo(() => {
     if (!game || !currentPlayer) return 0
@@ -157,14 +167,14 @@ function App() {
 
   // ---- navigate to lobby ----
   const navigateToLobby = () => {
-    clearGameSession(gameId)
-    setGameId('')
+    clearGameSession()
     setGame(null)
     setMySeatIndex(null)
     setRoster([])
     setLeavePending_(false)
     setShowdown(null)
     setRoomScreenMode('lobby')
+    goToLobby()
   }
 
   // ---- leave room ----
@@ -208,14 +218,14 @@ function App() {
       .catch(() => {})
   }, [])
 
-  // URL に gameId があれば初回ロード
+  // URL に tableId があれば初回ロード
   useEffect(() => {
-    if (!session.initialGameId) return
-    void refreshGame(session.initialGameId)
-    void refreshMembers(session.initialGameId)
-    void refreshTable(session.initialGameId)
+    if (!gameId) return
+    void refreshGame(gameId)
+    void refreshMembers(gameId)
+    void refreshTable(gameId)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [session.initialGameId])
+  }, [])  // mount 時のみ
 
   // isMyTurn 変化で actionAmount をリセット
   useEffect(() => {
@@ -313,8 +323,7 @@ function App() {
     try { await apiLogout() } catch { /* ignore */ }
     setCurrentUser(null)
     setMyName('')
-    clearGameSession(gameId)
-    setGameId('')
+    clearGameSession()
     setGame(null)
     setTable(null)
     setMySeatIndex(null)
@@ -380,10 +389,9 @@ function App() {
         setLoading(true)
         try {
           await doTableJoin(data.id, name, buyInAmount)
-          setGameId(data.id)
+          goToTable(data.id)
           setGame(data.game ?? null)
           setTable(data)
-          window.history.replaceState(null, '', `?tableId=${data.id}`)
           await refreshGame(data.id)
         } catch (err) {
           setError(formatErrorMessage(err))
@@ -414,20 +422,18 @@ function App() {
 
   const lobbyJoinWithBuyIn = async (tableId: string) => {
     setRoomScreenMode('room')
-    setGameId(tableId)
     setTable(null)
     setShowdown(null)
-    window.history.replaceState(null, '', `?tableId=${tableId}`)
+    goToTable(tableId)
     await refreshGame(tableId)
     await refreshMembers(tableId)
     const fetchedTable = await refreshTable(tableId)
     if (!myName.trim()) return
 
     const backToLobby = () => {
-      setGameId('')
       setTable(null)
       setRoomScreenMode('lobby')
-      window.history.replaceState(null, '', window.location.pathname)
+      goToLobby()
     }
 
     const doJoin = async (buyInAmount: number) => {

--- a/mapoker-frontend/src/hooks/useTableSession.ts
+++ b/mapoker-frontend/src/hooks/useTableSession.ts
@@ -2,24 +2,21 @@ import { useEffect, useMemo, useState } from 'react'
 import { clearSession, readSession, writeSession } from '../api'
 import type { RoomMember, StoredSession } from '../types'
 
-export function useTableSession(roster: RoomMember[]) {
-  const [gameId, setGameId] = useState('')
+/**
+ * テーブルセッション管理 hook。
+ * gameId は React Router の useParams から受け取る（URLが正規表現）。
+ */
+export function useTableSession(gameId: string, roster: RoomMember[]) {
   const [myName, setMyName] = useState('')
   const [mySeatIndex, setMySeatIndex] = useState<number | null>(null)
 
-  // URL パラメータから gameId を初期化（mount 時のみ）
-  const [initialGameId] = useState(() => {
-    const params = new URLSearchParams(window.location.search)
-    return params.get('tableId') ?? params.get('gameId') ?? ''
-  })
-
-  useEffect(() => {
-    if (initialGameId) setGameId(initialGameId)
-  }, [initialGameId])
-
   // gameId が変わったら localStorage からセッションを復元
   useEffect(() => {
-    if (!gameId) return
+    if (!gameId) {
+      setMyName('')
+      setMySeatIndex(null)
+      return
+    }
     const data = readSession(gameId)
     if (data) {
       setMyName(data.name)
@@ -60,19 +57,15 @@ export function useTableSession(roster: RoomMember[]) {
     writeSession(tableId, session)
   }
 
-  const clearGameSession = (tableId: string) => {
-    clearSession(tableId)
-    window.history.replaceState(null, '', window.location.pathname)
-    setGameId('')
+  const clearGameSession = () => {
+    if (gameId) clearSession(gameId)
     setMySeatIndex(null)
   }
 
   return {
-    gameId, setGameId,
     myName, setMyName,
     mySeatIndex, setMySeatIndex,
     mySeat, inferredSeatIndex,
-    initialGameId,
     persistSession, clearGameSession,
   }
 }

--- a/mapoker-frontend/src/main.tsx
+++ b/mapoker-frontend/src/main.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import { GoogleOAuthProvider } from '@react-oauth/google'
 import './index.css'
 import App from './App.tsx'
@@ -13,8 +14,10 @@ const googleClientId =
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <GoogleOAuthProvider clientId={googleClientId}>
-      <App />
-    </GoogleOAuthProvider>
+    <BrowserRouter>
+      <GoogleOAuthProvider clientId={googleClientId}>
+        <App />
+      </GoogleOAuthProvider>
+    </BrowserRouter>
   </StrictMode>,
 )


### PR DESCRIPTION
Closes #85 (Phase 3)

## Summary

React Router を導入し、URL 状態管理を明確化。

## 変更内容

| 項目 | 変更前 | 変更後 |
|---|---|---|
| URL 形式 | `/?tableId=xxx` | `/table/:tableId` |
| URL 管理 | `window.history.replaceState()` | `useNavigate()` |
| テーブルID 取得 | `useState` + URL パース | `useMatch('/table/:tableId')` |
| セッション復元 | mount時に `window.location.search` 解析 | `gameId` を props として受け取り |

## 変更ファイル

- `package.json` — `react-router-dom` 追加
- `src/main.tsx` — `BrowserRouter` でラップ
- `src/App.tsx` — `useNavigate` + `useMatch` に移行、`gameId` state を削除
- `src/hooks/useTableSession.ts` — `gameId` を引数として受け取る方式に変更

## インフラ対応

nginx.conf に `try_files $uri $uri/ /index.html` が既に設定済みのため、サーバー側の変更不要。

## Test plan

- [ ] `npx tsc --noEmit` 型エラーなし
- [ ] `/table/xxx` を直接アクセスしてゲーム画面が表示されること
- [ ] テーブル作成・参加後に URL が `/table/xxx` に変わること
- [ ] 退席後に URL が `/` に戻ること
- [ ] ページリロード後にセッションが復元されること
- [ ] 招待 URL が `/table/xxx` 形式になっていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)