### PR TITLE
feat: エラーハンドリング改善 + サーバーログ充実

### DIFF
--- a/mapoker-backend/pom.xml
+++ b/mapoker-backend/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.mapoker</groupId>
 	<artifactId>mapoker-backend</artifactId>
-	<version>1.1.7</version>
+	<version>1.1.8</version>
 	<name/>
 	<description/>
 	<url/>

--- a/mapoker-backend/src/main/java/com/mapoker/interfaces/http/GlobalExceptionHandler.java
+++ b/mapoker-backend/src/main/java/com/mapoker/interfaces/http/GlobalExceptionHandler.java
@@ -1,6 +1,8 @@
 package com.mapoker.interfaces.http;
 
 import com.mapoker.interfaces.http.dto.ErrorResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
@@ -16,64 +18,43 @@ import java.util.stream.Collectors;
 
 /**
  * Spring の {@code @RestControllerAdvice} として HTTP 例外を API エラー応答へ変換するハンドラです。
+ *
+ * <p>4xx（クライアントエラー）は WARN ログ、5xx（サーバーエラー）は ERROR ログ＋スタックトレースを出力します。
+ * 500 応答ではユーザーに内部詳細を返さず、汎用メッセージのみを返します。
  */
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    /**
-     * 未検出エラーを 404 応答へ変換します。
-     *
-     * @param e 発生した例外
-     * @return エラー応答
-     */
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
     @ExceptionHandler(NoSuchElementException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public ErrorResponse handleNotFound(NoSuchElementException e) {
+        log.warn("Not found: {}", e.getMessage());
         return ErrorResponse.of("not_found", e.getMessage());
     }
 
-    /**
-     * 不正な入力エラーを 400 応答へ変換します。
-     *
-     * @param e 発生した例外
-     * @return エラー応答
-     */
     @ExceptionHandler(IllegalArgumentException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ErrorResponse handleBadRequest(IllegalArgumentException e) {
+        log.warn("Bad request: {}", e.getMessage());
         return ErrorResponse.of("invalid_request", e.getMessage());
     }
 
-    /**
-     * 状態不整合エラーを 400 応答へ変換します。
-     *
-     * @param e 発生した例外
-     * @return エラー応答
-     */
     @ExceptionHandler(IllegalStateException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ErrorResponse handleInvalidState(IllegalStateException e) {
+        log.warn("Invalid state: {}", e.getMessage());
         return ErrorResponse.of("invalid_action", e.getMessage());
     }
 
-    /**
-     * 権限不足エラーを 403 応答へ変換します。
-     *
-     * @param e 発生した例外
-     * @return エラー応答
-     */
     @ExceptionHandler(AccessDeniedException.class)
     @ResponseStatus(HttpStatus.FORBIDDEN)
     public ErrorResponse handleAccessDenied(AccessDeniedException e) {
+        log.warn("Access denied: {}", e.getMessage());
         return ErrorResponse.of("forbidden", e.getMessage());
     }
 
-    /**
-     * Bean Validation の入力検証エラーを 400 応答へ変換します。
-     *
-     * @param e 発生した例外
-     * @return エラー応答
-     */
     @ExceptionHandler(MethodArgumentNotValidException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ErrorResponse handleValidation(MethodArgumentNotValidException e) {
@@ -83,43 +64,33 @@ public class GlobalExceptionHandler {
         if (message.isBlank()) {
             message = "request validation failed";
         }
+        log.warn("Validation failed: {}", message);
         return ErrorResponse.of("invalid_request", message);
     }
 
-    /**
-     * パラメータ制約違反を 400 応答へ変換します。
-     *
-     * @param e 発生した例外
-     * @return エラー応答
-     */
     @ExceptionHandler(ConstraintViolationException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ErrorResponse handleConstraintViolation(ConstraintViolationException e) {
+        log.warn("Constraint violation: {}", e.getMessage());
         return ErrorResponse.of("invalid_request", e.getMessage());
     }
 
-    /**
-     * 読み取り不能なリクエスト本文を 400 応答へ変換します。
-     *
-     * @param e 発生した例外
-     * @return エラー応答
-     */
     @ExceptionHandler(HttpMessageNotReadableException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ErrorResponse handleUnreadableMessage(HttpMessageNotReadableException e) {
+        log.warn("Unreadable request body: {}", e.getMessage());
         return ErrorResponse.of("invalid_request", "malformed request body");
     }
 
     /**
-     * 想定外例外を 500 応答へ変換します。
-     *
-     * @param e 発生した例外
-     * @return エラー応答
+     * 想定外の例外を 500 応答へ変換します。
+     * ユーザーには汎用メッセージのみを返し、内部詳細はサーバーログに記録します。
      */
     @ExceptionHandler(Exception.class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     public ErrorResponse handleGeneral(Exception e) {
-        return ErrorResponse.of("internal_error", e.getMessage());
+        log.error("Unhandled exception", e);
+        return ErrorResponse.of("internal_error", "サーバーエラーが発生しました");
     }
 
     private String formatFieldError(FieldError error) {

--- a/mapoker-backend/src/main/resources/application.properties
+++ b/mapoker-backend/src/main/resources/application.properties
@@ -39,3 +39,10 @@ avatar.storage-path=${AVATAR_STORAGE_PATH:/data/uploads/avatars}
 # Multipart upload limits
 spring.servlet.multipart.max-file-size=2MB
 spring.servlet.multipart.max-request-size=2MB
+
+# Logging
+logging.level.com.mapoker=INFO
+logging.level.com.mapoker.interfaces.http=DEBUG
+logging.level.org.springframework.web=WARN
+logging.level.org.springframework.security=WARN
+logging.pattern.console=%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n

--- a/mapoker-backend/src/test/java/com/mapoker/interfaces/http/GlobalExceptionHandlerTest.java
+++ b/mapoker-backend/src/test/java/com/mapoker/interfaces/http/GlobalExceptionHandlerTest.java
@@ -154,6 +154,7 @@ class GlobalExceptionHandlerTest {
         var response = handler.handleGeneral(new RuntimeException("unexpected"));
 
         assertThat(response.error().code()).isEqualTo("internal_error");
-        assertThat(response.error().message()).isEqualTo("unexpected");
+        // 内部詳細は返さず汎用メッセージのみ
+        assertThat(response.error().message()).isEqualTo("サーバーエラーが発生しました");
     }
 }

--- a/mapoker-frontend/src/App.tsx
+++ b/mapoker-frontend/src/App.tsx
@@ -216,7 +216,8 @@ function App() {
     void fetchVersion()
       .then((res) => setAppVersion(res.version))
       .catch(() => {})
-  }, [])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []) // mount 時のみ実行
 
   // URL に tableId があれば初回ロード
   useEffect(() => {
@@ -282,9 +283,20 @@ function App() {
 
   // ---- helpers ----
   function formatErrorMessage(err: unknown) {
-    const message = err instanceof Error ? err.message : String(err)
-    if (message === 'insufficient funds') return t('insufficientFunds')
-    return message
+    const code = err instanceof Error ? err.message : String(err)
+    const codeMap: Record<string, string> = {
+      insufficient_funds: t('insufficientFunds'),
+      not_found:          t('errNotFound'),
+      forbidden:          t('errForbidden'),
+      invalid_action:     t('errInvalidAction'),
+      internal_error:     t('errServerError'),
+      http_400:           t('errBadRequest'),
+      http_401:           t('errUnauthorized'),
+      http_403:           t('errForbidden'),
+      http_404:           t('errNotFound'),
+      http_500:           t('errServerError'),
+    }
+    return codeMap[code] ?? t('errUnknown')
   }
 
   const refreshTable = async (id = gameId) => {

--- a/mapoker-frontend/src/api.ts
+++ b/mapoker-frontend/src/api.ts
@@ -30,7 +30,7 @@ export async function uploadFile<T>(path: string, file: File): Promise<T> {
   const data = text ? (JSON.parse(text) as T | ApiError) : ({} as T)
   if (!res.ok) {
     const err = data as ApiError
-    throw new Error(err.error?.message ?? `Request failed: ${res.status}`)
+    throw new Error(err.error?.code ?? `http_${res.status}`)
   }
   return data as T
 }
@@ -134,7 +134,7 @@ export async function fetchJSON<T>(path: string, options: RequestInit = {}): Pro
   const data = text ? (JSON.parse(text) as T | ApiError) : ({} as T)
   if (!res.ok) {
     const err = data as ApiError
-    throw new Error(err.error?.message ?? `Request failed: ${res.status}`)
+    throw new Error(err.error?.code ?? `http_${res.status}`)
   }
   return data as T
 }

--- a/mapoker-frontend/src/components/GameScreen/TableArea.tsx
+++ b/mapoker-frontend/src/components/GameScreen/TableArea.tsx
@@ -155,6 +155,8 @@ export function TableArea({
       setFlippingIndices(new Set())
       timers.forEach(window.clearTimeout)
     }
+    // game.players / isShowdown はアニメーション遅延計算のみに使用し意図的に省略
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [communityCount])
 
   // ショーダウン開始時点のスタックを凍結（ペイアウト前の値を保持）

--- a/mapoker-frontend/src/i18n.ts
+++ b/mapoker-frontend/src/i18n.ts
@@ -232,6 +232,13 @@ const ja = {
   errSelectSeat: '有効なシートを選択してください',
   errMissingRoom: 'ルームIDがありません',
   errSelectSeatFirst: 'アクション前にシートを選択してください',
+  errServerError: 'サーバーエラーが発生しました。しばらくしてから再試行してください',
+  errNotFound: '対象が見つかりませんでした',
+  errForbidden: 'この操作は許可されていません',
+  errBadRequest: 'リクエストが正しくありません',
+  errUnauthorized: 'ログインが必要です',
+  errInvalidAction: 'この操作は現在実行できません',
+  errUnknown: 'エラーが発生しました',
 
   // --- 動的テキスト（{n} はシート番号）---
   seatN: 'シート{n}',


### PR DESCRIPTION
## Summary

- ユーザーへの内部エラー漏洩を防止
- サーバーログを充実させ、500 エラーの原因追跡を可能に
- フロントでエラーコードを日本語に変換

## 変更内容

### バックエンド

**GlobalExceptionHandler にログを追加**
- 4xx（クライアントエラー）: `log.warn()` でメッセージのみ記録
- 5xx（想定外エラー）: `log.error()` でスタックトレース付き記録
- `handleGeneral` の 500 応答を `e.getMessage()` → `"サーバーエラーが発生しました"` に変更（内部詳細を漏洩しない）

**application.properties にログ設定を追加**
```
logging.level.com.mapoker=INFO
logging.level.com.mapoker.interfaces.http=DEBUG
logging.pattern.console=%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n
```

### フロントエンド

- `api.ts`: エラー throw を `error.message` → `error.code` ベースに変更
- `App.tsx`: `formatErrorMessage` を `code → i18n` マッピングに変更
- `i18n.ts`: エラーコード対応の日本語メッセージを追加

## Test plan

- [x] `./mvnw test` 220テスト全通過
- [x] `npm run lint` エラーなし
- [x] `npx tsc --noEmit` 型エラーなし
- [ ] 存在しないテーブルにアクセス → 「対象が見つかりませんでした」と表示される
- [ ] サーバーで 500 が発生 → フロントに「サーバーエラーが発生しました」と出て、サーバーログにスタックトレースが記録される

🤖 Generated with [Claude Code](https://claude.com/claude-code)