### PR TITLE
feat: サーバーログ管理を整備（ファイル出力 + ローテーション）

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -66,8 +66,11 @@ services:
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-}
       # Avatar storage
       AVATAR_STORAGE_PATH: /data/uploads/avatars
+      # Logging
+      LOGS_LOCATION: /data/logs
     volumes:
       - ${UPLOADS_LOCATION:-/srv/mapoker/data/uploads}/avatars:/data/uploads/avatars
+      - ${LOGS_LOCATION:-/srv/mapoker/data/logs}:/data/logs
     ports:
       - "8080:8080"
     healthcheck:
@@ -87,6 +90,9 @@ services:
       dockerfile: Dockerfile
     environment:
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}
+      LOGS_LOCATION: /data/logs
+    volumes:
+      - ${LOGS_LOCATION:-/srv/mapoker/data/logs}:/data/logs
     container_name: mapoker-frontend
     restart: unless-stopped
     depends_on:

--- a/mapoker-backend/docker-entrypoint.sh
+++ b/mapoker-backend/docker-entrypoint.sh
@@ -1,6 +1,16 @@
 #!/bin/sh
-# アップロードディレクトリを root で作成・権限設定してから appuser で起動する
+# ディレクトリ作成・権限設定を root で行い、その後 appuser で起動する
+
+# アバター
 mkdir -p /data/uploads/avatars
 chown -R appuser:appgroup /data/uploads 2>/dev/null || true
 chmod -R 755 /data/uploads 2>/dev/null || true
-exec su-exec appuser java -jar /app/app.jar
+
+# ログ
+mkdir -p "${LOGS_LOCATION:-/data/logs}/backend"
+chown -R appuser:appgroup "${LOGS_LOCATION:-/data/logs}" 2>/dev/null || true
+chmod -R 755 "${LOGS_LOCATION:-/data/logs}" 2>/dev/null || true
+
+exec su-exec appuser java \
+  -Dlogging.file.dir="${LOGS_LOCATION:-/data/logs}" \
+  -jar /app/app.jar

--- a/mapoker-backend/src/main/resources/logback-spring.xml
+++ b/mapoker-backend/src/main/resources/logback-spring.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+  <!-- ログ出力先ディレクトリ（環境変数 LOGS_LOCATION、デフォルトはプロジェクト相対の ./logs） -->
+  <springProperty name="LOG_DIR" source="logging.file.dir" defaultValue="./logs"/>
+
+  <!-- ===== コンソール出力（常時） ===== -->
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <charset>UTF-8</charset>
+    </encoder>
+  </appender>
+
+  <!-- ===== ファイル出力（docker プロファイル時のみ有効） ===== -->
+  <springProfile name="postgresql,production">
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+      <file>${LOG_DIR}/backend/application.log</file>
+      <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+        <fileNamePattern>${LOG_DIR}/backend/application.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+        <maxFileSize>100MB</maxFileSize>
+        <maxHistory>30</maxHistory>
+        <totalSizeCap>2GB</totalSizeCap>
+      </rollingPolicy>
+      <encoder>
+        <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        <charset>UTF-8</charset>
+      </encoder>
+    </appender>
+  </springProfile>
+
+  <!-- アプリケーションロガー -->
+  <logger name="com.mapoker" level="INFO"/>
+  <logger name="com.mapoker.interfaces.http" level="DEBUG"/>
+  <logger name="org.springframework.web" level="WARN"/>
+  <logger name="org.springframework.security" level="WARN"/>
+
+  <!-- root: 本番（postgresql/production プロファイル）はファイルにも出力 -->
+  <springProfile name="postgresql,production">
+    <root level="WARN">
+      <appender-ref ref="CONSOLE"/>
+      <appender-ref ref="FILE"/>
+    </root>
+  </springProfile>
+
+  <!-- それ以外（local/test）はコンソールのみ -->
+  <springProfile name="!postgresql &amp; !production">
+    <root level="WARN">
+      <appender-ref ref="CONSOLE"/>
+    </root>
+  </springProfile>
+</configuration>

--- a/mapoker-frontend/Dockerfile
+++ b/mapoker-frontend/Dockerfile
@@ -13,11 +13,17 @@ RUN npm run build
 # Runtime stage - nginx
 FROM nginx:alpine
 
+# logrotate と dcron（Alpine の cron 実装）をインストール
+RUN apk add --no-cache logrotate dcron
+
 # Copy built files
 COPY --from=builder /app/dist /usr/share/nginx/html
 
 # Copy nginx config
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+# logrotate 設定
+COPY logrotate-nginx.conf /etc/logrotate.d/nginx-app
 
 # Copy entrypoint (generates config.js from env vars at startup)
 COPY docker-entrypoint.sh /docker-entrypoint.sh

--- a/mapoker-frontend/docker-entrypoint.sh
+++ b/mapoker-frontend/docker-entrypoint.sh
@@ -1,8 +1,24 @@
 #!/bin/sh
-# 起動時に環境変数から config.js を生成する
+# 起動時に環境変数から config.js を生成し、ログディレクトリを作成してから nginx を起動する
+
 cat > /usr/share/nginx/html/config.js << EOF
 window.__CONFIG__ = {
   googleClientId: '${GOOGLE_CLIENT_ID}',
 }
 EOF
+
+# ログディレクトリを作成
+mkdir -p "${LOGS_LOCATION:-/data/logs}/frontend"
+
+# nginx の access_log / error_log のパスを環境変数に合わせて書き換え
+NGINX_CONF=/etc/nginx/conf.d/default.conf
+if [ -n "${LOGS_LOCATION}" ]; then
+  sed -i "s|/data/logs/frontend|${LOGS_LOCATION}/frontend|g" "${NGINX_CONF}"
+fi
+
+# crond をバックグラウンドで起動（logrotate の定期実行）
+# 毎日 00:05 に実行
+echo "5 0 * * * /usr/sbin/logrotate /etc/logrotate.d/nginx-app" | crontab -
+crond -b
+
 exec nginx -g 'daemon off;'

--- a/mapoker-frontend/logrotate-nginx.conf
+++ b/mapoker-frontend/logrotate-nginx.conf
@@ -1,0 +1,13 @@
+/data/logs/frontend/*.log {
+    daily
+    rotate 30
+    size 100M
+    missingok
+    notifempty
+    compress
+    delaycompress
+    dateext
+    postrotate
+        nginx -s reopen 2>/dev/null || true
+    endscript
+}

--- a/mapoker-frontend/nginx.conf
+++ b/mapoker-frontend/nginx.conf
@@ -3,6 +3,10 @@ server {
     listen [::]:80 default_server;
     server_name _;
 
+    # ログ出力先（環境変数 LOGS_LOCATION、デフォルト /data/logs）
+    access_log /data/logs/frontend/access.log combined;
+    error_log  /data/logs/frontend/error.log warn;
+
     # Gzip compression
     gzip on;
     gzip_types text/plain text/css text/javascript application/json application/javascript;


### PR DESCRIPTION
## Summary

`LOGS_LOCATION=./data/logs` 以下にフロント・バックエンドのログを出力し、ローテーションで肥大化を防ぐ。

## ディレクトリ構造

```
$LOGS_LOCATION/
  backend/
    application.log                  # Spring Boot アプリログ（現行）
    application.2026-05-19.0.log.gz  # ローテーション済み（gzip圧縮）
  frontend/
    access.log   # nginx アクセスログ
    error.log    # nginx エラーログ
```

## 変更内容

### バックエンド (Spring Boot)
- `logback-spring.xml` を追加
  - `postgresql` / `production` プロファイル時のみファイル出力（テスト環境に影響なし）
  - `SizeAndTimeBasedRollingPolicy`: 100MB/ファイル、30日保持、合計 2GB 上限、gzip 圧縮
- `docker-entrypoint.sh`: ログディレクトリ作成 + JVM に `-Dlogging.file.dir` を渡す

### フロントエンド (nginx)
- `nginx.conf`: `access_log` / `error_log` をファイル出力に変更
- `Dockerfile`: `logrotate` + `dcron` をインストール
- `logrotate-nginx.conf`: 日次、100MB 上限、30日保持、gzip 圧縮、nginx reload
- `docker-entrypoint.sh`: ログディレクトリ作成 + `crond` バックグラウンド起動

### docker-compose.yaml
- `LOGS_LOCATION=/data/logs` を両サービスに追加
- `${LOGS_LOCATION:-/srv/mapoker/data/logs}:/data/logs` ボリュームをマウント

## .env.local での設定例

```env
LOGS_LOCATION=./data/logs
```

## Test plan

- [x] `./mvnw test` 220テスト全通過（logback-spring.xml のプロファイル分岐で本番以外はファイル不要）
- [ ] Docker Compose 起動後、`./data/logs/backend/application.log` が作成されること
- [ ] Docker Compose 起動後、`./data/logs/frontend/access.log` が作成されること
- [ ] 100MB 超えでローテーションされること（または日付変更で）

🤖 Generated with [Claude Code](https://claude.com/claude-code)